### PR TITLE
IMTA-2478-Storing the PDF Certificate

### DIFF
--- a/service/src/main/java/uk/gov/defra/tracesx/certificate/CertificateConfiguration.java
+++ b/service/src/main/java/uk/gov/defra/tracesx/certificate/CertificateConfiguration.java
@@ -1,20 +1,18 @@
 package uk.gov.defra.tracesx.certificate;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import uk.gov.defra.tracesx.certificate.service.blobstorage.BlobStorage;
+import uk.gov.defra.tracesx.certificate.service.blobstorage.Storage;
 
 @Configuration
 @EnableConfigurationProperties
-@EnableJpaRepositories("uk.gov.defra.tracesx.certificate.dao.repositories")
 public class CertificateConfiguration {
-  //Custom Configuration properties can be loaded here
+  // Custom Configuration properties can be loaded here
 
   @Bean
-  public ObjectMapper getObjectMapper() {
-    return new ObjectMapper();
+  public Storage getBlobStorage() {
+    return new BlobStorage();
   }
 }

--- a/service/src/main/java/uk/gov/defra/tracesx/certificate/dao/entities/Certificate.java
+++ b/service/src/main/java/uk/gov/defra/tracesx/certificate/dao/entities/Certificate.java
@@ -1,42 +1,54 @@
 package uk.gov.defra.tracesx.certificate.dao.entities;
 
-import java.util.UUID;
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.Table;
+import java.util.Arrays;
+import java.util.Objects;
 
-@Entity
-@Table(name = "certificate")
 public class Certificate {
 
-  @Id
-  @GeneratedValue(strategy = GenerationType.AUTO)
-  private UUID id;
+  private String referenceNumber;
 
-  private String document;
+  private byte[] document;
 
   public Certificate() {}
 
-  public Certificate(UUID id, String document) {
-    this.id = id;
-    this.document = document;
+  public String getReferenceNumber() {
+    return referenceNumber;
   }
 
-  public UUID getId() {
-    return id;
+  public void setReferenceNumber(String referenceNumber) {
+    this.referenceNumber = referenceNumber;
   }
 
-  public void setId(UUID id) {
-    this.id = id;
-  }
-
-  public String getDocument() {
+  public byte[] getDocument() {
     return document;
   }
 
-  public void setDocument(String document) {
+  public void setDocument(byte[] document) {
+    this.document = document;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    Certificate that = (Certificate) o;
+    return Objects.equals(referenceNumber, that.referenceNumber)
+        && Arrays.equals(document, that.document);
+  }
+
+  @Override
+  public int hashCode() {
+    int result = Objects.hash(referenceNumber);
+    result = 31 * result + Arrays.hashCode(document);
+    return result;
+  }
+
+  public Certificate(String referenceNumber, byte[] document) {
+    this.referenceNumber = referenceNumber;
     this.document = document;
   }
 }

--- a/service/src/main/java/uk/gov/defra/tracesx/certificate/dao/repositories/CertificateRepository.java
+++ b/service/src/main/java/uk/gov/defra/tracesx/certificate/dao/repositories/CertificateRepository.java
@@ -1,9 +1,0 @@
-package uk.gov.defra.tracesx.certificate.dao.repositories;
-
-import java.util.UUID;
-import org.springframework.data.repository.CrudRepository;
-import org.springframework.stereotype.Repository;
-import uk.gov.defra.tracesx.certificate.dao.entities.Certificate;
-
-@Repository
-public interface CertificateRepository extends CrudRepository<Certificate, UUID> {}

--- a/service/src/main/java/uk/gov/defra/tracesx/certificate/resource/CertificateResource.java
+++ b/service/src/main/java/uk/gov/defra/tracesx/certificate/resource/CertificateResource.java
@@ -1,24 +1,13 @@
 package uk.gov.defra.tracesx.certificate.resource;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.github.fge.jsonpatch.JsonPatchException;
-import java.io.IOException;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import uk.gov.defra.tracesx.certificate.service.CertificateService;
@@ -27,8 +16,6 @@ import uk.gov.defra.tracesx.certificate.service.CertificateService;
 @RequestMapping("/certificate")
 public class CertificateResource {
 
-  private static final String CONTENT_TYPE_MERGE_PATCH = "application/merge-patch+json";
-  private static final String CONTENT_TYPE_COMMAND_PATCH = "application/json-patch+json";
   private static final Logger LOGGER = LoggerFactory.getLogger(CertificateResource.class);
 
   private final CertificateService certificateService;
@@ -38,55 +25,14 @@ public class CertificateResource {
     this.certificateService = certificateService;
   }
 
-  @PostMapping(
-      consumes = MediaType.APPLICATION_JSON_VALUE,
-      produces = MediaType.APPLICATION_JSON_VALUE)
-  public ResponseEntity insert(@RequestBody JsonNode entity) throws URISyntaxException {
-    UUID id = certificateService.create(entity);
-    LOGGER.info("POST id: {}", id);
-    URI createdLocation = new URI("/certificate/" + id.toString());
-    return ResponseEntity.created(createdLocation).build();
-  }
-
-  @GetMapping(value = "/download/{id}")
-  public ResponseEntity<byte[]> downloadCertificate(@PathVariable("id") UUID id)
-      throws IOException {
-    LOGGER.info("GET id: {}", id);
+  @GetMapping(value = "/{referenceNumber}/{etag}")
+  public ResponseEntity<byte[]> getCertificate(
+      @PathVariable("referenceNumber") String referenceNumber, @PathVariable("etag") String etag) {
+    LOGGER.info("GET referenceNumber: {}, etag: {}", referenceNumber, etag);
     return ResponseEntity.ok()
         .contentType(MediaType.APPLICATION_PDF)
-        .header(HttpHeaders.CONTENT_DISPOSITION,
-            "attachment; filename=\"" + id + ".pdf\"")
-        .body(certificateService.downloadCertificate(id));
-  }
-
-  @PatchMapping(
-      value = "/{id}",
-      consumes = {
-          CONTENT_TYPE_MERGE_PATCH,
-          CONTENT_TYPE_COMMAND_PATCH,
-          MediaType.APPLICATION_JSON_VALUE,
-      },
-      produces = MediaType.APPLICATION_JSON_VALUE)
-  public ResponseEntity patch(
-      @PathVariable("id") UUID id,
-      @RequestHeader(value = "Content-Type") String contentType,
-      @RequestBody JsonNode patch)
-      throws JsonPatchException, IOException {
-
-    boolean mergePatch = false;
-    if (contentType.equals(CONTENT_TYPE_MERGE_PATCH)) {
-      mergePatch = true;
-    }
-
-    certificateService.update(id, patch, mergePatch);
-    LOGGER.info("PATCH id: {}", id);
-    return ResponseEntity.ok().build();
-  }
-
-  @DeleteMapping(value = "/{id}")
-  public ResponseEntity delete(@PathVariable("id") UUID id) {
-    certificateService.deleteData(id);
-    LOGGER.info("DELETE id: {}", id);
-    return ResponseEntity.ok().build();
+        .header(
+            HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + referenceNumber + ".pdf\"")
+        .body(certificateService.getCertificate(referenceNumber, etag).getDocument());
   }
 }

--- a/service/src/main/java/uk/gov/defra/tracesx/certificate/service/CertificateService.java
+++ b/service/src/main/java/uk/gov/defra/tracesx/certificate/service/CertificateService.java
@@ -1,102 +1,37 @@
 package uk.gov.defra.tracesx.certificate.service;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.github.fge.jsonpatch.JsonPatchException;
-import java.io.IOException;
-import java.util.UUID;
-import java.io.BufferedReader;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.util.stream.Collectors;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import uk.gov.defra.tracesx.certificate.dao.entities.Certificate;
-import uk.gov.defra.tracesx.certificate.dao.repositories.CertificateRepository;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.github.fge.jsonpatch.JsonPatch;
-import com.github.fge.jsonpatch.mergepatch.JsonMergePatch;
-import org.everit.json.schema.Schema;
-import org.everit.json.schema.loader.SchemaLoader;
-import org.json.JSONException;
-import org.json.JSONObject;
-import org.springframework.core.io.ClassPathResource;
-import org.everit.json.schema.ValidationException;
+import uk.gov.defra.tracesx.certificate.service.blobstorage.BlobStorage;
+import uk.gov.defra.tracesx.certificate.service.blobstorage.BlobStorageIdentifier;
 import uk.gov.defra.tracesx.certificate.utillities.CertificatePDFGenerator;
 
 @Service
 public class CertificateService {
 
-  private final CertificateRepository certificateRepository;
   private final CertificatePDFGenerator pdfGenerator;
-  protected final Schema schema;
-  private final ObjectMapper mapper;
+  private final BlobStorage storage;
 
   @Autowired
-  public CertificateService(CertificateRepository certificateRepository,
-      CertificatePDFGenerator pdfGenerator, ObjectMapper mapper) throws IOException {
-    this.certificateRepository = certificateRepository;
+  public CertificateService(CertificatePDFGenerator pdfGenerator, BlobStorage storage) {
     this.pdfGenerator = pdfGenerator;
-    this.mapper = mapper;
-    this.schema = loadSchema();
+    this.storage = storage;
   }
 
-  public UUID create(JsonNode document) {
-    validateAgainstSchema(document);
-    Certificate certificate = new Certificate();
-    certificate.setDocument(document.toString());
-    return certificateRepository.save(certificate).getId();
+  public Certificate getCertificate(String referenceNumber, String etag) {
+    BlobStorageIdentifier key = new BlobStorageIdentifier(referenceNumber, etag);
+    return storage.getCertificate(key).orElseGet(() -> createCertificate(referenceNumber, key));
   }
 
-  public JsonNode get(UUID id) throws IOException {
-    Certificate certificate = certificateRepository.findById(id).get();
-    return mapper.readTree(certificate.getDocument());
+  private Certificate createCertificate(String referenceNumber, BlobStorageIdentifier key) {
+    byte[] bytes = pdfGenerator.generate(referenceNumber);
+    Certificate certificate = new Certificate(referenceNumber, bytes);
+    storeCertificate(key, certificate);
+    return certificate;
   }
 
-  public byte[] downloadCertificate(UUID id) {
-    Certificate certificate = new Certificate();
-    certificate.setId(id);
-    return pdfGenerator.generate(certificate);
-  }
-
-public void update(UUID id, JsonNode patch, boolean isMergePatch)
-      throws JsonPatchException, IOException {
-    Certificate certificateOrig = certificateRepository.findById(id).get();
-    JsonNode certificateUpdated = performPatch(certificateOrig, isMergePatch, patch);
-    validateAgainstSchema(certificateUpdated);
-    certificateRepository.save(new Certificate(id, certificateUpdated.toString()));
-  }
-
-  public void deleteData(UUID id) {
-    certificateRepository.deleteById(id);
-  }
-
-  protected void validateAgainstSchema(JsonNode jsonToValidate) throws ValidationException {
-    JSONObject jsonObjectToValidate = new JSONObject(jsonToValidate.toString());
-    schema.validate(jsonObjectToValidate);
-  }
-
-  protected JsonNode performPatch(
-      Certificate certificateOrig, boolean isMergePatch, JsonNode patch)
-      throws IOException, JsonPatchException {
-    
-    JsonNode jsonOriginalDocument = mapper.readTree(certificateOrig.getDocument());
-    final JsonNode certificateUpdated;
-    if (isMergePatch) {
-      final JsonMergePatch preparedMergePatch = JsonMergePatch.fromJson(patch);
-      certificateUpdated = preparedMergePatch.apply(jsonOriginalDocument);
-    } else {
-      final JsonPatch preparedCommandPatch = JsonPatch.fromJson(patch);
-      certificateUpdated = preparedCommandPatch.apply(jsonOriginalDocument);
-    }
-    return certificateUpdated;
-  }
-
-  protected final Schema loadSchema() throws IOException, JSONException {
-    InputStream resource = new ClassPathResource("serviceSchema.json").getInputStream();
-    BufferedReader reader = new BufferedReader(new InputStreamReader(resource));
-    String schemaString = reader.lines().collect(Collectors.joining(""));
-    JSONObject jsonSchema = new JSONObject(schemaString);
-    SchemaLoader loader = SchemaLoader.builder().schemaJson(jsonSchema).build();
-    return loader.load().build();
+  private void storeCertificate(BlobStorageIdentifier key, Certificate certificate) {
+    storage.storeCertificate(key, certificate);
   }
 }

--- a/service/src/main/java/uk/gov/defra/tracesx/certificate/service/blobstorage/BlobStorage.java
+++ b/service/src/main/java/uk/gov/defra/tracesx/certificate/service/blobstorage/BlobStorage.java
@@ -1,0 +1,33 @@
+package uk.gov.defra.tracesx.certificate.service.blobstorage;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import org.springframework.stereotype.Repository;
+import uk.gov.defra.tracesx.certificate.dao.entities.Certificate;
+
+@Repository
+public class BlobStorage implements Storage {
+
+  private Map<BlobStorageIdentifier, Certificate> blobStorageHashMap = new HashMap<>();
+  //  This will be replaced by actual Blob storage once it is available
+
+  @Override
+  public boolean storeCertificate(BlobStorageIdentifier key, Certificate certificate) {
+    if (!certificateExists(key)) {
+      blobStorageHashMap.put(key, certificate);
+      return true;
+    }
+    return false;
+  }
+
+  @Override
+  public Optional<Certificate> getCertificate(BlobStorageIdentifier key) {
+    return Optional.ofNullable(blobStorageHashMap.get(key));
+  }
+
+  @Override
+  public boolean certificateExists(BlobStorageIdentifier key) {
+    return blobStorageHashMap.containsKey(key);
+  }
+}

--- a/service/src/main/java/uk/gov/defra/tracesx/certificate/service/blobstorage/BlobStorageIdentifier.java
+++ b/service/src/main/java/uk/gov/defra/tracesx/certificate/service/blobstorage/BlobStorageIdentifier.java
@@ -1,0 +1,27 @@
+package uk.gov.defra.tracesx.certificate.service.blobstorage;
+
+import javax.validation.constraints.NotNull;
+
+public class BlobStorageIdentifier {
+  private final String referenceNumber;
+  private final String etag;
+
+  public BlobStorageIdentifier(@NotNull String referenceNumber, @NotNull String etag) {
+    this.referenceNumber = referenceNumber;
+    this.etag = etag;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (obj instanceof BlobStorageIdentifier) {
+      BlobStorageIdentifier s = (BlobStorageIdentifier) obj;
+      return referenceNumber.equals(s.referenceNumber) && etag.equals(s.etag);
+    }
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+    return (referenceNumber + etag).hashCode();
+  }
+}

--- a/service/src/main/java/uk/gov/defra/tracesx/certificate/service/blobstorage/Storage.java
+++ b/service/src/main/java/uk/gov/defra/tracesx/certificate/service/blobstorage/Storage.java
@@ -1,0 +1,12 @@
+package uk.gov.defra.tracesx.certificate.service.blobstorage;
+
+import java.util.Optional;
+import uk.gov.defra.tracesx.certificate.dao.entities.Certificate;
+
+public interface Storage {
+  boolean storeCertificate(BlobStorageIdentifier key, Certificate certificate);
+
+  Optional<Certificate> getCertificate(BlobStorageIdentifier key);
+
+  boolean certificateExists(BlobStorageIdentifier key);
+}

--- a/service/src/main/java/uk/gov/defra/tracesx/certificate/utillities/CertificatePDFGenerator.java
+++ b/service/src/main/java/uk/gov/defra/tracesx/certificate/utillities/CertificatePDFGenerator.java
@@ -1,29 +1,35 @@
 package uk.gov.defra.tracesx.certificate.utillities;
 
 import com.itextpdf.text.Document;
+import com.itextpdf.text.DocumentException;
 import com.itextpdf.text.Paragraph;
 import com.itextpdf.text.pdf.PdfWriter;
 import java.io.File;
 import java.io.FileOutputStream;
+import java.io.IOException;
 import java.nio.file.Files;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
-import uk.gov.defra.tracesx.certificate.dao.entities.Certificate;
 
 @Component("pdfGenerator")
 public class CertificatePDFGenerator {
-  public byte[] generate(Certificate certificate) {
-    String filePath = "tempCertificate-" + certificate.getId() + ".pdf";
+  private static final Logger LOGGER = LoggerFactory.getLogger(CertificatePDFGenerator.class);
+
+  public byte[] generate(String referenceNumber) {
+    String filePath = "tempCertificate-" + referenceNumber + ".pdf";
     try {
       Document document = new Document();
       PdfWriter.getInstance(document, new FileOutputStream(filePath));
       document.open();
-      document.add(new Paragraph(certificate.getId().toString()));
+      document.add(new Paragraph(referenceNumber));
       document.close();
       File pdf = new File(filePath);
       byte[] file = Files.readAllBytes(pdf.toPath());
       Files.delete(pdf.toPath());
       return file;
-    } catch (Exception e) {
+    } catch (IOException | DocumentException e) {
+      LOGGER.error(String.format("Exception occurred while generating PDF: %s", e.getMessage()));
       return null;
     }
   }

--- a/service/src/test/java/uk/gov/defra/tracesx/certificate/CertificateConfigurationTest.java
+++ b/service/src/test/java/uk/gov/defra/tracesx/certificate/CertificateConfigurationTest.java
@@ -1,11 +1,21 @@
 package uk.gov.defra.tracesx.certificate;
 
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
 import org.junit.Before;
+import org.junit.Test;
 
 public class CertificateConfigurationTest {
-  
+
+  private CertificateConfiguration certificateConfiguration;
+
   @Before
   public void setUp() {
+    certificateConfiguration = new CertificateConfiguration();
   }
-  
+
+  @Test
+  public void testBeanIsLoaded() {
+    assertNotNull(certificateConfiguration.getBlobStorage());
+  }
 }

--- a/service/src/test/java/uk/gov/defra/tracesx/certificate/dao/entities/CertificateTest.java
+++ b/service/src/test/java/uk/gov/defra/tracesx/certificate/dao/entities/CertificateTest.java
@@ -7,35 +7,27 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class CertificateTest {
-  
-  @Before
-  public void setUp() {
-  }
-  
-  @Test
-  public void verifyIdProperty() {
-    //Given
-    Certificate instance = new Certificate();
-    UUID id = UUID.randomUUID();
-    
-    //When
-    instance.setId(id);
 
-    //Then
-    assertEquals(id, instance.getId());
+  @Before
+  public void setUp() {}
+
+  @Test
+  public void verifyReferenceProperty() {
+    Certificate instance = new Certificate();
+    String referenceNumber = UUID.randomUUID().toString();
+
+    instance.setReferenceNumber(referenceNumber);
+
+    assertEquals(referenceNumber, instance.getReferenceNumber());
   }
 
   @Test
   public void verifyDocumentProperty() {
-    //Given
     Certificate instance = new Certificate();
-    String jsonDocument = "{\"test\": 123}";
-    
-    //When
-    instance.setDocument(jsonDocument);
+    byte[] document = "Some data to be stored as binary".getBytes();
 
-    //Then
-    assertEquals(jsonDocument, instance.getDocument());
-    
+    instance.setDocument(document);
+
+    assertEquals(document, instance.getDocument());
   }
 }

--- a/service/src/test/java/uk/gov/defra/tracesx/certificate/resource/CertificateResourceTest.java
+++ b/service/src/test/java/uk/gov/defra/tracesx/certificate/resource/CertificateResourceTest.java
@@ -1,21 +1,12 @@
-
 package uk.gov.defra.tracesx.certificate.resource;
 
-import static org.junit.Assert.assertEquals;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 
-import com.fasterxml.jackson.core.JsonFactory;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.github.fge.jsonpatch.JsonPatchException;
-import java.io.IOException;
-import java.net.URISyntaxException;
-import java.util.Arrays;
 import java.util.Random;
 import java.util.UUID;
 import org.junit.Before;
@@ -23,161 +14,34 @@ import org.junit.Test;
 import org.mockito.Mock;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import uk.gov.defra.tracesx.certificate.dao.entities.Certificate;
 import uk.gov.defra.tracesx.certificate.service.CertificateService;
 
 public class CertificateResourceTest {
 
-  private static final String EXAMPLE_PARSER = "{\"k1\":\"v1\"}";
-  private static final String MERGE_PATCH_TYPE = "application/merge-patch+json";
-  private static final String COMMAND_PATCH_TYPE = "application/json-patch+json";
+  @Mock CertificateService certificateService;
 
-  private JsonNode node;
-
-  @Mock
-  CertificateService certificateService;
-  
   @Before
-  public void setUp() throws IOException {
+  public void setUp() {
     initMocks(this);
-    ObjectMapper mapper = new ObjectMapper();
-    JsonFactory factory = mapper.getFactory();
-    JsonParser jsonParser = factory.createParser(EXAMPLE_PARSER);
-    node = mapper.readTree(jsonParser);
   }
 
   @Test
-  public void insertCallsServiceWithPostedJson() throws URISyntaxException {
-    //Given
+  public void downloadCertificateReturnsExpectedResponse() {
     CertificateResource resource = new CertificateResource(certificateService);
-    when(certificateService.create(any())).thenReturn(UUID.randomUUID());
-    
-    //When
-    resource.insert(node);
-    
-    //Then
-    verify(certificateService, times(1)).create(node);
-  }
+    String referenceNumber = UUID.randomUUID().toString();
+    String etag = UUID.randomUUID().toString();
 
-  @Test
-  public void insertReturnsCreatedLocation() throws URISyntaxException {
-    //Given
-    CertificateResource resource = new CertificateResource(certificateService);
-    UUID id = UUID.randomUUID();
-    when(certificateService.create(any())).thenReturn(id);
-    
-    //When
-    ResponseEntity responseEntity = resource.insert(null);
-    
-    //Then
-    assertEquals(HttpStatus.CREATED, responseEntity.getStatusCode());
-    assertEquals("/certificate/" + id.toString() ,responseEntity.getHeaders().getLocation().toString());
-  }
+    byte[] expectedBinaryData = new byte[20];
+    new Random().nextBytes(expectedBinaryData);
+    Certificate expectedCertificate = new Certificate(referenceNumber, expectedBinaryData);
 
-  @Test
-  public void patchCallsEntityServiceWithMergePatchType() throws IOException, JsonPatchException {
-    //Given
-    CertificateResource resource = new CertificateResource(certificateService);
-    UUID id = UUID.randomUUID();
-    
-    //When
-    resource.patch(id, MERGE_PATCH_TYPE, node);
-    
-    //Then
-    verify(certificateService, times(1)).update(id, node, true);
-  }
+    when(certificateService.getCertificate(any(), any())).thenReturn(expectedCertificate);
 
-  @Test
-  public void patchCallsEntityServiceWithCommandPatchType() throws IOException, JsonPatchException {
-    //Given
-    CertificateResource resource = new CertificateResource(certificateService);
-    UUID id = UUID.randomUUID();
-    
-    //When
-    resource.patch(id, COMMAND_PATCH_TYPE, node);
-    
-    //Then
-    verify(certificateService, times(1)).update(id, node, false);
-  }
-  
-  @Test
-  public void patchCallsEntityServiceWithIdAndPatch() throws JsonPatchException, IOException {
-    //Given
-    CertificateResource resource = new CertificateResource(certificateService);
-    UUID id = UUID.randomUUID();
-    
-    //When
-    resource.patch(id, COMMAND_PATCH_TYPE, node);
-    
-    //Then
-    verify(certificateService, times(1)).update(id, node, false);
-  }
-  
-  @Test
-  public void patchReturnsOkayStatus() throws IOException, JsonPatchException {
-    //Given
-    CertificateResource resource = new CertificateResource(certificateService);
-    UUID id = UUID.randomUUID();
-    
-    //When
-    ResponseEntity responseEntity = resource.patch(id, COMMAND_PATCH_TYPE, node);
-    
-    //Then
-    assertEquals(HttpStatus.OK, responseEntity.getStatusCode());
-  }
 
-  @Test
-  public void deleteCallsServiceWithId() {
-    //Given
-    CertificateResource resource = new CertificateResource(certificateService);
-    UUID id = UUID.randomUUID();
-    
-    //When
-    resource.delete(id);
-    
-    //Then
-    verify(certificateService, times(1)).deleteData(id);
-  }
-  
-  @Test
-  public void deleteReturnsHttpStatusOkay() {
-    //Given
-    CertificateResource resource = new CertificateResource(certificateService);
-    UUID id = UUID.randomUUID();
-    
-    //When
-    ResponseEntity entity = resource.delete(id);
-    
-    //Then
-    assertEquals(HttpStatus.OK, entity.getStatusCode());
-  }
+    ResponseEntity response = resource.getCertificate(referenceNumber, etag);
 
-  @Test
-  public void downloadCertificateReturnsExpectedResponse() throws IOException {
-    //Given
-    CertificateResource resource = new CertificateResource(certificateService);
-    UUID id = UUID.randomUUID();
-    byte[] mockFile = new byte[20];
-    new Random().nextBytes(mockFile);
-    when(certificateService.downloadCertificate(any())).thenReturn(mockFile);
-
-    //When
-    ResponseEntity entity = resource.downloadCertificate(id);
-
-    //Then
-    assertEquals(HttpStatus.OK, entity.getStatusCode());
-    assertEquals(true, Arrays.equals((byte[]) entity.getBody(), mockFile));
-  }
-
-  @Test
-  public void downloadCertificateServiceWithId() throws IOException {
-    //Given
-    CertificateResource resource = new CertificateResource(certificateService);
-    UUID id = UUID.randomUUID();
-
-    //When
-    resource.downloadCertificate(id);
-
-    //Then
-    verify(certificateService, times(1)).downloadCertificate(id);
+    assertThat(HttpStatus.OK, equalTo(response.getStatusCode()));
+    assertEquals((byte[]) response.getBody(), expectedBinaryData);
   }
 }

--- a/service/src/test/java/uk/gov/defra/tracesx/certificate/service/CertificateServiceTest.java
+++ b/service/src/test/java/uk/gov/defra/tracesx/certificate/service/CertificateServiceTest.java
@@ -1,276 +1,60 @@
 package uk.gov.defra.tracesx.certificate.service;
 
-import com.fasterxml.jackson.core.JsonFactory;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.github.fge.jsonpatch.JsonPatchException;
-import java.io.IOException;
-import java.util.Arrays;
-import java.util.Optional;
-import java.util.Random;
-import java.util.UUID;
-import org.everit.json.schema.Schema;
-import org.everit.json.schema.ValidationException;
-import static org.junit.Assert.assertEquals;
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.ArgumentCaptor;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
-import org.mockito.Mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
+
+import java.util.Random;
+import java.util.UUID;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
 import uk.gov.defra.tracesx.certificate.dao.entities.Certificate;
-import uk.gov.defra.tracesx.certificate.dao.repositories.CertificateRepository;
+import uk.gov.defra.tracesx.certificate.service.blobstorage.BlobStorage;
 import uk.gov.defra.tracesx.certificate.utillities.CertificatePDFGenerator;
 
 public class CertificateServiceTest {
 
-  @Mock
-  CertificateRepository certificateRepository;
+  @Mock CertificatePDFGenerator pdfGenerator;
+  @Mock BlobStorage blobStorage;
 
-  @Mock
-  CertificatePDFGenerator pdfGenerator;
-
-  @Mock
-  Schema schema;
-
-  private ObjectMapper mapper = new ObjectMapper();
-  private JsonNode entity;
   private CertificateService certificateService;
-  
+
   @Before
-  public void setUp() throws IOException {
+  public void setUp() {
     initMocks(this);
-    certificateService = new CertificateService(certificateRepository, pdfGenerator, mapper);
-    ObjectMapper mapper = new ObjectMapper();
-    JsonFactory factory = mapper.getFactory();
-    JsonParser jsonParser = factory.createParser("{\"certificate\":\"aName\"}");
-    entity = mapper.readTree(jsonParser);
-  }
-  
-  @Test
-  public void certificateServiceLoadsSchema() throws IOException {
-    //Given
-    CertificateService certificateServiceNew;
-    
-    //When
-    certificateServiceNew = new CertificateService(certificateRepository, pdfGenerator, mapper);
-    
-    //Then
-    assertEquals("Certificate schema", certificateServiceNew.schema.getDescription());
-  }
-
-  @Test (expected = ValidationException.class)
-  public void createValidatesAgainstSchema() throws IOException {
-    //Given
-    ObjectMapper mapper = new ObjectMapper();
-    JsonFactory factory = mapper.getFactory();
-    JsonParser jsonParser = factory.createParser("{\"k1\":\"v1\"}");
-    JsonNode invalidEntity = mapper.readTree(jsonParser);
-    
-    //When
-    certificateService.create(invalidEntity);
-    
-    //Then
-    //Validation exception thrown
-  }
-
-  @Test
-  public void createsSavesAsNewEntity() throws IOException {
-    //Given
-    UUID idSavedWith = UUID.randomUUID();
-    Certificate certificate = new Certificate();
-    certificate.setId(idSavedWith);
-    when(certificateRepository.save(any())).thenReturn(certificate);
-    
-    //When
-    UUID entityId = certificateService.create(entity);
-    
-    //Then
-    verify(certificateRepository, times(1)).save(any());
-    assertEquals(idSavedWith, entityId);
-  }
-
-  @Test
-  public void createSavesPassedJsonObject() throws IOException {
-    //Given
-    UUID idSavedWith = UUID.randomUUID();
-    Certificate certificate = new Certificate();
-    certificate.setId(idSavedWith);
-    ArgumentCaptor<Certificate> captorForDocument = ArgumentCaptor.forClass(Certificate.class);
-    when(certificateRepository.save(captorForDocument.capture())).thenReturn(certificate);
-    
-    //When
-    certificateService.create(entity);
-    
-    //Then
-    assertEquals(null, captorForDocument.getValue().getId());
-    assertEquals(entity.toString(), captorForDocument.getValue().getDocument());
-  }
-
-  @Test
-  public void getCallsRepositoryWithId() throws IOException {
-    //Given
-    UUID id = UUID.randomUUID();
-    Certificate record = new Certificate();
-    record.setId(id);
-    record.setDocument("");
-    when(certificateRepository.findById(any())).thenReturn(Optional.of(record));
-    
-    //When
-    certificateService.get(id);
-    
-    //Then
-    verify(certificateRepository, times(1)).findById(id);
-    verify(certificateRepository, times(1)).findById(any());
-  }
-
-  @Test
-  public void getReturnsDocumentFromRepository() throws IOException {
-    //Given
-    UUID id = UUID.randomUUID();
-    Certificate record = new Certificate();
-    record.setId(id);
-    record.setDocument(entity.toString());
-    when(certificateRepository.findById(any())).thenReturn(Optional.of(record));
-    
-    //When
-    JsonNode entityReturned = certificateService.get(id);
-    
-    //Then
-    assertEquals("aName", entityReturned.get("certificate").textValue());
-  }
-
-  @Test
-  public void updateGetsDocumentFromRepository() throws JsonPatchException, IOException {
-    //Given
-    UUID id = UUID.randomUUID();
-    Certificate record = new Certificate();
-    record.setId(id);
-    record.setDocument(entity.toString());
-    when(certificateRepository.findById(id)).thenReturn(Optional.of(record));
-    ObjectMapper mapper = new ObjectMapper();
-    JsonFactory factory = mapper.getFactory();
-    JsonParser jsonParser = factory.createParser("{\"certificate\":\"newName\"}");
-    JsonNode mergePatch = mapper.readTree(jsonParser);
-    
-    //When
-    certificateService.update(id, mergePatch, true);
-    
-    //Then
-    verify(certificateRepository, times(1)).findById(id);
-    verify(certificateRepository, times(1)).findById(any());
-  }
-
-  @Test
-  public void updatePerformsMergePatchWhenSaving() throws IOException, JsonPatchException {
-    //Given
-    UUID id = UUID.randomUUID();
-    Certificate record = new Certificate();
-    record.setId(id);
-    record.setDocument(entity.toString());
-    when(certificateRepository.findById(id)).thenReturn(Optional.of(record));
-    ObjectMapper mapper = new ObjectMapper();
-    JsonFactory factory = mapper.getFactory();
-    JsonParser jsonParser = factory.createParser("{\"certificate\":\"patchedName\"}");
-    JsonNode mergePatch = mapper.readTree(jsonParser);
-    ArgumentCaptor<Certificate> captorForDocument = ArgumentCaptor.forClass(Certificate.class);
-    when(certificateRepository.save(captorForDocument.capture())).thenReturn(null);
-    
-    //When
-    certificateService.update(id, mergePatch, true);
-    
-    //Then
-    assertEquals("{\"certificate\":\"patchedName\"}", captorForDocument.getValue().getDocument());
-  }
-  
-  @Test
-  public void updatePerformsCommandPatchWhenSaving() throws IOException, JsonPatchException {
-    //Given
-    UUID id = UUID.randomUUID();
-    Certificate record = new Certificate();
-    record.setId(id);
-    record.setDocument(entity.toString());
-    when(certificateRepository.findById(id)).thenReturn(Optional.of(record));
-    ObjectMapper mapper = new ObjectMapper();
-    JsonFactory factory = mapper.getFactory();
-    JsonParser jsonParser = factory.createParser("[{ \"op\": \"replace\", \"path\": \"/certificate\", \"value\": \"patchedName\"}]");
-    JsonNode mergePatch = mapper.readTree(jsonParser);
-    ArgumentCaptor<Certificate> captorForDocument = ArgumentCaptor.forClass(Certificate.class);
-    when(certificateRepository.save(captorForDocument.capture())).thenReturn(null);
-    
-    //When
-    certificateService.update(id, mergePatch, false);
-    
-    //Then
-    assertEquals("{\"certificate\":\"patchedName\"}", captorForDocument.getValue().getDocument());
-  }
-
-  @Test (expected=ValidationException.class)
-  public void updateValidatesPatchedEntityAgainstSchema() throws IOException, JsonPatchException {
-    //Given
-    UUID id = UUID.randomUUID();
-    Certificate record = new Certificate();
-    record.setId(id);
-    record.setDocument(entity.toString());
-    when(certificateRepository.findById(id)).thenReturn(Optional.of(record));
-    ObjectMapper mapper = new ObjectMapper();
-    JsonFactory factory = mapper.getFactory();
-    JsonParser jsonParser = factory.createParser("{\"extraName\":\"extraName\"}");
-    JsonNode mergePatch = mapper.readTree(jsonParser);
-    
-    //When
-    certificateService.update(id, mergePatch, true);
-    
-    //Then
-    //Validation Exception should be thrown
-  }
-
-  @Test
-  public void deleteCallsRepositoryOnceWithId() {
-    //Given
-    UUID id = UUID.randomUUID();
-    
-    //When
-    certificateService.deleteData(id);
-    
-    //Then
-    verify(certificateRepository, times(1)).deleteById(id);
-    verify(certificateRepository, times(1)).deleteById(any());
+    certificateService = new CertificateService(pdfGenerator, blobStorage);
   }
 
   @Test
   public void downloadCertificateReturnsExpectedByteArray() {
-    //Given
-    UUID id = UUID.randomUUID();
-    Certificate certificate = new Certificate();
-    certificate.setId(id);
-    byte[] mockFile = new byte[20];
-    new Random().nextBytes(mockFile);
-    when(pdfGenerator.generate(any())).thenReturn(mockFile);
+    String referenceNumber = UUID.randomUUID().toString();
+    String etag = UUID.randomUUID().toString();
 
-    //When
-    byte[] actual = certificateService.downloadCertificate(id);
+    byte[] document = new byte[20];
+    new Random().nextBytes(document);
 
-    //Then
-    assertEquals(true, Arrays.equals(mockFile, actual));
+    Certificate expectedCertificate = new Certificate(referenceNumber, document);
+
+    when(pdfGenerator.generate(any())).thenReturn(document);
+    Certificate actualCertificate = certificateService.getCertificate(referenceNumber, etag);
+
+    assertEquals(expectedCertificate, actualCertificate);
+    assertEquals(actualCertificate.getDocument(), document);
   }
 
   @Test
   public void downloadCertificateCallsPdfGeneratorOnce() {
-    //Given
-    UUID id = UUID.randomUUID();
-    Certificate certificate = new Certificate();
-    certificate.setId(id);
-    when(pdfGenerator.generate(any())).thenReturn(new byte[20]);
+    String referenceNumber = UUID.randomUUID().toString();
+    String etag = UUID.randomUUID().toString();
 
-    //When
-    certificateService.downloadCertificate(id);
+    when(pdfGenerator.generate(any())).thenReturn("Some Binary Data".getBytes());
 
-    //Then
+    certificateService.getCertificate(referenceNumber, etag);
+
     verify(pdfGenerator, times(1)).generate(any());
   }
 }

--- a/service/src/test/java/uk/gov/defra/tracesx/certificate/service/blobstorage/BlobStorageTest.java
+++ b/service/src/test/java/uk/gov/defra/tracesx/certificate/service/blobstorage/BlobStorageTest.java
@@ -1,0 +1,48 @@
+package uk.gov.defra.tracesx.certificate.service.blobstorage;
+
+import static org.mockito.MockitoAnnotations.initMocks;
+
+import java.util.UUID;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import uk.gov.defra.tracesx.certificate.dao.entities.Certificate;
+
+public class BlobStorageTest {
+
+  private Storage storage;
+  private BlobStorageIdentifier key;
+  private Certificate certificate;
+  private String referenceNumber;
+  private String etag;
+
+  @Before
+  public void setUp() {
+    initMocks(this);
+    storage = new BlobStorage();
+    referenceNumber = UUID.randomUUID().toString();
+    etag = UUID.randomUUID().toString();
+    key = new BlobStorageIdentifier(referenceNumber, etag);
+    certificate = new Certificate();
+    certificate.setReferenceNumber(referenceNumber);
+    certificate.setDocument("Some binary data".getBytes());
+  }
+
+  @Test
+  public void testStoreCertificate() {
+    storage.storeCertificate(key, certificate);
+    Assert.assertEquals(certificate, storage.getCertificate(key).get());
+  }
+
+  @Test
+  public void testGetCertificate() {
+    storage.storeCertificate(key, certificate);
+    Assert.assertEquals(certificate, storage.getCertificate(key).get());
+  }
+
+  @Test
+  public void testIsCertificateExists() {
+    storage.storeCertificate(key, certificate);
+    Assert.assertTrue(storage.getCertificate(key).isPresent());
+  }
+}

--- a/service/src/test/java/uk/gov/defra/tracesx/certificate/utillities/CertificatePDFGeneratorTest.java
+++ b/service/src/test/java/uk/gov/defra/tracesx/certificate/utillities/CertificatePDFGeneratorTest.java
@@ -1,28 +1,23 @@
 package uk.gov.defra.tracesx.certificate.utillities;
 
-import java.io.IOException;
 import java.util.UUID;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import uk.gov.defra.tracesx.certificate.dao.entities.Certificate;
-
 
 public class CertificatePDFGeneratorTest {
 
   private CertificatePDFGenerator pdfGenerator;
-  private Certificate certificate;
-  private final UUID certificateUUID = UUID.randomUUID();
+  private final String referenceNumber = UUID.randomUUID().toString();
 
   @Before
-  public void setUp() throws IOException {
-    certificate = new Certificate();
-    certificate.setId(certificateUUID);
-    certificate.setId(UUID.randomUUID());
+  public void setUp() {
     pdfGenerator = new CertificatePDFGenerator();
   }
 
   @Test
-  public void shouldGenerateExpectedPDF(){
-    byte[] pdfFile = pdfGenerator.generate(certificate);
+  public void shouldGeneratePDF() {
+    byte[] generatedPdfBinaryData = pdfGenerator.generate(referenceNumber);
+    Assert.assertNotNull(generatedPdfBinaryData);
   }
 }


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | harsh vasudev (KAINOS) |
> | **GitLab Project** | [imports/certificate-microservice](https://giteux.azure.defra.cloud/imports/certificate-microservice) |
> | **GitLab Merge Request** | [IMTA-2478-Storing the PDF Certificate](https://giteux.azure.defra.cloud/imports/certificate-microservice/merge_requests/3) |
> | **GitLab MR Number** | [3](https://giteux.azure.defra.cloud/imports/certificate-microservice/merge_requests/3) |
> | **Date Originally Opened** | Tue, 13 Nov 2018 |
> | **Approved on GitLab by** | Ghost User, alexander shaw (KAINOS) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Storing the generated pdf certificate in a temparary storage until blob is available. Initial draft.