### PR TITLE
feature/imta 3451 version number not set on ap is or website

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,5 +6,5 @@ javaPipeline {
     SERVICE_VERSION = "1.0"
     ENVIRONMENT = "Sandpit"
     SELENIUM_BRANCH = "master"
-    WAIT_FOR_VERSION = "false"
+    WAIT_FOR_VERSION = "true"
 }


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | Glenn Hamilton (Kainos) |
> | **GitLab Project** | [imports/certificate-microservice](https://giteux.azure.defra.cloud/imports/certificate-microservice) |
> | **GitLab Merge Request** | [feature/imta 3451 version number not set...](https://giteux.azure.defra.cloud/imports/certificate-microservice/merge_requests/6) |
> | **GitLab MR Number** | [6](https://giteux.azure.defra.cloud/imports/certificate-microservice/merge_requests/6) |
> | **Date Originally Opened** | Tue, 27 Nov 2018 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **closed** on GitLab

## Original Description

- Set `WAIT_FOR_VERSION` to `false` due to this being a `dropwizard` application.

https://eaflood.atlassian.net/browse/IMTA-3451