### PR TITLE
IMTA-3513 move basic auth to a different header

### DIFF
--- a/integration/pom.xml
+++ b/integration/pom.xml
@@ -64,6 +64,12 @@
       <version>4.12</version>
       <scope>test</scope>
     </dependency>
+      <dependency>
+          <groupId>junit</groupId>
+          <artifactId>junit</artifactId>
+          <version>4.12</version>
+          <scope>test</scope>
+      </dependency>
   </dependencies>
     <name>TracesX-Certificate-Integration</name>
 </project>

--- a/integration/src/test/java/uk/gov/defra/tracesx/certificate/integration/CertificateApi.java
+++ b/integration/src/test/java/uk/gov/defra/tracesx/certificate/integration/CertificateApi.java
@@ -1,21 +1,29 @@
 package uk.gov.defra.tracesx.certificate.integration;
-
 import static io.restassured.RestAssured.given;
-
+import static java.nio.charset.StandardCharsets.UTF_8;
 import io.restassured.response.Response;
+import java.io.UnsupportedEncodingException;
+import java.util.Base64;
 
 public class CertificateApi {
 
   private TestEnvironment testEnvironment;
 
+  public static final String COLON = ":";
+  public static final String BASIC = "Basic ";
+  private String encodedBasicAuth;
+
   public CertificateApi(TestEnvironment testEnvironment) {
     this.testEnvironment = testEnvironment;
   }
 
-  public Response getPdf(String htmlContent, String reference, String url) {
-    Response response = given()
-        .auth()
-        .basic(testEnvironment.getUsername(), testEnvironment.getPassword())
+  public Response getPdf(String htmlContent, String reference, String url) throws UnsupportedEncodingException {
+
+    encodedBasicAuth = BASIC + Base64.getEncoder().encodeToString(
+            new StringBuffer().append(testEnvironment.getUsername()).append(COLON).append(testEnvironment.getPassword()).toString().getBytes(
+                    UTF_8.name()));
+
+    Response response = given().header("x-auth-basic",encodedBasicAuth)
         .body(htmlContent)
         .when()
         .post(getUrl("/certificate/", reference, url))

--- a/integration/src/test/java/uk/gov/defra/tracesx/certificate/integration/CertificateServiceTest.java
+++ b/integration/src/test/java/uk/gov/defra/tracesx/certificate/integration/CertificateServiceTest.java
@@ -10,6 +10,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
 
+import java.io.UnsupportedEncodingException;
+
 @RunWith(SpringRunner.class)
 @ContextConfiguration(classes = CertificateTestConfig.class)
 public class CertificateServiceTest {
@@ -18,7 +20,7 @@ public class CertificateServiceTest {
   private CertificateApi certificateApi;
 
   @Test
-  public void shouldCreateCertificateFromHtml() {
+  public void shouldCreateCertificateFromHtml() throws UnsupportedEncodingException {
 
     String htmlContent = "<p>hello world</p>";
     String callBackUrl = "";
@@ -28,7 +30,7 @@ public class CertificateServiceTest {
   }
 
   @Test
-  public void shouldReturnBadRequestIfHtmlIsInvalid() {
+  public void shouldReturnBadRequestIfHtmlIsInvalid() throws UnsupportedEncodingException {
     String htmlContent = "<p>hello world</p";
     String callBackUrl = "";
     Response response = certificateApi.getPdf(htmlContent, "any-ref", callBackUrl);
@@ -37,7 +39,7 @@ public class CertificateServiceTest {
   }
 
   @Test
-  public void shouldCreateCertificateWithFont() {
+  public void shouldCreateCertificateWithFont() throws UnsupportedEncodingException {
     String htmlContent = "<p style='font-family: Arial Unicode MS;'>hello world</p>";
     String callBackUrl = "";
     Response response = certificateApi.getPdf(htmlContent, "any-ref", callBackUrl);

--- a/service/src/main/java/uk/gov/defra/tracesx/certificate/security/BasicAuthenticatorConfig.java
+++ b/service/src/main/java/uk/gov/defra/tracesx/certificate/security/BasicAuthenticatorConfig.java
@@ -16,8 +16,7 @@ public class BasicAuthenticatorConfig extends WebSecurityConfigurerAdapter {
             .anyRequest()
             .authenticated()
             .and()
-            .httpBasic()
-            .and()
+            .addFilter(new CustomBasicAuthenticationFilter(authenticationManager()))
             .csrf()
             .disable();
   }

--- a/service/src/main/java/uk/gov/defra/tracesx/certificate/security/CustomBasicAuthenticationFilter.java
+++ b/service/src/main/java/uk/gov/defra/tracesx/certificate/security/CustomBasicAuthenticationFilter.java
@@ -1,0 +1,159 @@
+package uk.gov.defra.tracesx.certificate.security;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.authentication.*;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.NullRememberMeServices;
+import org.springframework.security.web.authentication.RememberMeServices;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+public class CustomBasicAuthenticationFilter extends BasicAuthenticationFilter {
+
+    private RememberMeServices rememberMeServices = new NullRememberMeServices();
+    private AuthenticationDetailsSource<HttpServletRequest, ?> authenticationDetailsSource = new WebAuthenticationDetailsSource();
+    private static final Logger LOGGER = LoggerFactory.getLogger(CustomBasicAuthenticationFilter.class);
+    private static final String BASIC_AUTH_HEADER_KEY = "x-auth-basic";
+    private static final String BASIC_AUTH_PREFIX = "basic ";
+
+    public CustomBasicAuthenticationFilter(AuthenticationManager authenticationManager) {
+        super(authenticationManager);
+    }
+
+    @Override
+    public void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+                                 FilterChain chain) throws IOException, ServletException {
+
+        if (request.getHeader(BASIC_AUTH_HEADER_KEY) == null) {
+            SecurityContextHolder.getContext().setAuthentication(null);
+        }
+
+        String header = request.getHeader(BASIC_AUTH_HEADER_KEY);
+        if (header == null || !header.toLowerCase().startsWith(BASIC_AUTH_PREFIX)) {
+                chain.doFilter(request, response);
+                return;
+        }
+
+        try {
+            String[] decodedHeader = extractAndDecodeHeader(header, request);
+            assert decodedHeader.length == 2;
+            String username = decodedHeader[0];
+
+            if (authenticationIsRequired(username)) {
+                UsernamePasswordAuthenticationToken authRequest = new UsernamePasswordAuthenticationToken(
+                        username, decodedHeader[1]);
+                authRequest.setDetails(
+                        this.authenticationDetailsSource.buildDetails(request));
+                Authentication authResult = super.getAuthenticationManager()
+                        .authenticate(authRequest);
+                SecurityContextHolder.getContext().setAuthentication(authResult);
+                this.rememberMeServices.loginSuccess(request, response, authResult);
+                onSuccessfulAuthentication(request, response, authResult);
+            }
+
+        } catch (AuthenticationException failed) {
+            SecurityContextHolder.clearContext();
+            this.rememberMeServices.loginFail(request, response);
+            onUnsuccessfulAuthentication(request, response, failed);
+
+            if (super.isIgnoreFailure()) {
+                chain.doFilter(request, response);
+            }
+            else {
+                super.getAuthenticationEntryPoint().commence(request, response, failed);
+            }
+            return;
+        }
+        chain.doFilter(request, response);
+    }
+
+    /**
+     * Decodes the header into a username and password.
+     *
+     * @throws BadCredentialsException if the Basic header is not present or is not valid
+     * Base64
+     */
+    private String[] extractAndDecodeHeader(String header, HttpServletRequest request)
+            throws IOException {
+
+        byte[] base64Token = header.substring(6).getBytes(StandardCharsets.UTF_8.name());
+        byte[] decoded;
+        try {
+            decoded = Base64.getDecoder().decode(base64Token);
+        }
+        catch (IllegalArgumentException e) {
+            throw new BadCredentialsException(
+                    "Failed to decode basic authentication token");
+        }
+
+        String decodedHeader = new String(decoded, getCredentialsCharset(request));
+
+        int delim = decodedHeader.indexOf(":");
+
+        if (delim == -1) {
+            throw new BadCredentialsException("Invalid basic authentication token");
+        }
+        return new String[] { decodedHeader.substring(0, delim), decodedHeader.substring(delim + 1) };
+    }
+
+    private boolean authenticationIsRequired(String username) {
+        // Only reauthenticate if username doesn't match SecurityContextHolder and user
+        // isn't authenticated
+        // (see SEC-53)
+        Authentication existingAuth = SecurityContextHolder.getContext()
+                .getAuthentication();
+
+        if (existingAuth == null || !existingAuth.isAuthenticated()) {
+            return true;
+        }
+
+        // Limit username comparison to providers which use usernames (ie
+        // UsernamePasswordAuthenticationToken)
+        // (see SEC-348)
+
+        if (existingAuth instanceof UsernamePasswordAuthenticationToken
+                && !existingAuth.getName().equals(username)) {
+            return true;
+        }
+
+        // Handle unusual condition where an AnonymousAuthenticationToken is already
+        // present
+        // This shouldn't happen very often, as BasicProcessingFitler is meant to be
+        // earlier in the filter
+        // chain than AnonymousAuthenticationFilter. Nevertheless, presence of both an
+        // AnonymousAuthenticationToken
+        // together with a BASIC authentication request header should indicate
+        // reauthentication using the
+        // BASIC protocol is desirable. This behaviour is also consistent with that
+        // provided by form and digest,
+        // both of which force re-authentication if the respective header is detected (and
+        // in doing so replace
+        // any existing AnonymousAuthenticationToken). See SEC-610.
+        if (existingAuth instanceof AnonymousAuthenticationToken) {
+            return true;
+        }
+
+        return false;
+    }
+
+    @Override
+    public void setRememberMeServices(RememberMeServices rememberMeServices) {
+        this.rememberMeServices = rememberMeServices;
+    }
+
+    @Override
+    public void setAuthenticationDetailsSource(AuthenticationDetailsSource<HttpServletRequest, ?> authenticationDetailsSource) {
+        this.authenticationDetailsSource = authenticationDetailsSource;
+    }
+}

--- a/service/src/test/java/uk/gov/defra/tracesx/certificate/security/BasicAuthenticatorConfigIntegrationTest.java
+++ b/service/src/test/java/uk/gov/defra/tracesx/certificate/security/BasicAuthenticatorConfigIntegrationTest.java
@@ -15,11 +15,15 @@ import static org.junit.Assert.fail;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
 import org.springframework.mock.web.MockFilterChain;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.mock.web.MockServletContext;
 import org.springframework.security.access.ConfigAttribute;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.config.annotation.authentication.configuration.GlobalAuthenticationConfigurerAdapter;
 import org.springframework.security.web.FilterChainProxy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.access.intercept.DefaultFilterInvocationSecurityMetadataSource;
@@ -57,20 +61,20 @@ public class BasicAuthenticatorConfigIntegrationTest {
   @Test
   public void testRequestRequiresAuthorization() throws IOException, ServletException {
     //Given
-    loadConfig(BasicAuthenticatorConfig.class);
+    loadConfig(AuthenticationManagerCustomizer.class, BasicAuthenticatorConfig.class);
     this.request.setServletPath("/");
 
     //When
     this.springSecurityFilterChain.doFilter(this.request, this.response, this.chain);
 
     //Then
-    assertEquals(HttpServletResponse.SC_UNAUTHORIZED, this.response.getStatus());
+    assertEquals(HttpServletResponse.SC_FORBIDDEN, this.response.getStatus());
   }
 
   @Test
   public void verifyBasicAuthFilterCoversAllPaths() throws Exception {
     //Given
-    loadConfig(BasicAuthenticatorConfig.class);
+    loadConfig(AuthenticationManagerCustomizer.class, BasicAuthenticatorConfig.class);
     
     //When
     List<SecurityFilterChain> filterChain = this.springSecurityFilterChain.getFilterChains();
@@ -82,8 +86,8 @@ public class BasicAuthenticatorConfigIntegrationTest {
     FilterSecurityInterceptor filterSecurityInterceptor = null;
     List<Filter> filters = filterChain.get(0).getFilters();
     for(Filter currentFilter: filters){
-      if (currentFilter.getClass() == BasicAuthenticationFilter.class)
-        basicAuthenticationFilter = (BasicAuthenticationFilter) currentFilter;
+      if (currentFilter.getClass() == CustomBasicAuthenticationFilter.class)
+        basicAuthenticationFilter = (CustomBasicAuthenticationFilter) currentFilter;
       if (currentFilter.getClass() == FilterSecurityInterceptor.class)
         filterSecurityInterceptor = (FilterSecurityInterceptor) currentFilter;
     }
@@ -106,7 +110,7 @@ public class BasicAuthenticatorConfigIntegrationTest {
   @Test
   public void csrfIsDisabled() throws IOException, ServletException {
     //Given
-    loadConfig(BasicAuthenticatorConfig.class);
+    loadConfig(AuthenticationManagerCustomizer.class, BasicAuthenticatorConfig.class);
 
     //When
     List<SecurityFilterChain> filterChain = this.springSecurityFilterChain.getFilterChains();
@@ -129,4 +133,16 @@ public class BasicAuthenticatorConfigIntegrationTest {
 		this.context.refresh();
 		this.context.getAutowireCapableBeanFactory().autowireBean(this);
 	}
+
+    @Configuration
+    @Order(-1)
+    protected static class AuthenticationManagerCustomizer
+            extends GlobalAuthenticationConfigurerAdapter {
+
+        @Override
+        public void init(AuthenticationManagerBuilder auth) throws Exception {
+            auth.inMemoryAuthentication().withUser("username").password("password").roles("USER");
+        }
+    }
+
 }

--- a/service/src/test/java/uk/gov/defra/tracesx/certificate/service/CertificateServiceTest.java
+++ b/service/src/test/java/uk/gov/defra/tracesx/certificate/service/CertificateServiceTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.util.function.Supplier;
 import org.junit.Test;
@@ -30,7 +31,7 @@ public class CertificateServiceTest {
   private byte[] pdfBytes = new byte[200];
 
   @Test
-  public void shouldCreateCertificateWithHtmlContent() {
+  public void shouldCreateCertificateWithHtmlContent() throws UnsupportedEncodingException {
     givenService();
 
     when(pdfGenerator.createPdf(CERT_HTML_CONTENT, BASE_URI)).thenReturn(pdfBytes);


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | Ramanujan Uppili (KAINOS) |
> | **GitLab Project** | [imports/certificate-microservice](https://giteux.azure.defra.cloud/imports/certificate-microservice) |
> | **GitLab Merge Request** | [IMTA-3513 move basic auth to a different...](https://giteux.azure.defra.cloud/imports/certificate-microservice/merge_requests/10) |
> | **GitLab MR Number** | [10](https://giteux.azure.defra.cloud/imports/certificate-microservice/merge_requests/10) |
> | **Date Originally Opened** | Mon, 3 Dec 2018 |
> | **Approved on GitLab by** | Matthew Trousdale, praveen seepathi (DDTS) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

_No description_