### PR TITLE
IMTA-3489 Add support for three part roles used by identity

### DIFF
--- a/service/src/main/java/uk/gov/defra/tracesx/certificate/security/IdTokenUserDetails.java
+++ b/service/src/main/java/uk/gov/defra/tracesx/certificate/security/IdTokenUserDetails.java
@@ -5,7 +5,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
 @Data
@@ -14,7 +14,7 @@ import org.springframework.security.core.userdetails.UserDetails;
 @EqualsAndHashCode
 public class IdTokenUserDetails implements UserDetails {
 
-  private List<SimpleGrantedAuthority> authorities;
+  private List<GrantedAuthority> authorities;
   private String username; // upn
   private String idToken;
   private String displayName; // name

--- a/service/src/main/java/uk/gov/defra/tracesx/certificate/security/OrganisationGrantedAuthority.java
+++ b/service/src/main/java/uk/gov/defra/tracesx/certificate/security/OrganisationGrantedAuthority.java
@@ -1,0 +1,15 @@
+package uk.gov.defra.tracesx.certificate.security;
+
+import lombok.Builder;
+import lombok.Data;
+import org.springframework.security.core.GrantedAuthority;
+
+/** Identity roles are formatted organisation:role:status */
+@Data
+@Builder
+public class OrganisationGrantedAuthority implements GrantedAuthority {
+
+  private String authority;
+  private String organisation;
+  private String status;
+}

--- a/service/src/main/java/uk/gov/defra/tracesx/certificate/security/RoleToAuthorityMapper.java
+++ b/service/src/main/java/uk/gov/defra/tracesx/certificate/security/RoleToAuthorityMapper.java
@@ -1,0 +1,33 @@
+package uk.gov.defra.tracesx.certificate.security;
+
+import static java.util.stream.Collectors.toList;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.stereotype.Component;
+
+@Component
+public class RoleToAuthorityMapper {
+
+  private static final int ORG_INDEX = 0;
+  private static final int ROLE_INDEX = 1;
+  private static final int STATUS_INDEX = 2;
+
+  public List<GrantedAuthority> mapRoles(List<String> roles) {
+    return roles.stream().map(this::mapRole).collect(toList());
+  }
+
+  private GrantedAuthority mapRole(String role) {
+    String parts[] = role.split(":");
+    if (parts.length == 3) {
+      return OrganisationGrantedAuthority.builder()
+          .organisation(parts[ORG_INDEX])
+          .authority(parts[ROLE_INDEX])
+          .status(parts[STATUS_INDEX])
+          .build();
+    }
+    return new SimpleGrantedAuthority(role);
+  }
+}

--- a/service/src/main/java/uk/gov/defra/tracesx/certificate/security/jwt/JwtUserMapper.java
+++ b/service/src/main/java/uk/gov/defra/tracesx/certificate/security/jwt/JwtUserMapper.java
@@ -1,15 +1,18 @@
 package uk.gov.defra.tracesx.certificate.security.jwt;
 
+import static uk.gov.defra.tracesx.certificate.security.jwt.JwtContants.ROLES;
+
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.GrantedAuthority;
 import org.springframework.stereotype.Component;
 import uk.gov.defra.tracesx.certificate.exceptions.InsSecurityException;
 import uk.gov.defra.tracesx.certificate.security.IdTokenUserDetails;
+import uk.gov.defra.tracesx.certificate.security.RoleToAuthorityMapper;
 
 @Component
 public class JwtUserMapper {
@@ -18,6 +21,13 @@ public class JwtUserMapper {
   public static final String NAME = "name";
   public static final String UPN = "upn";
   public static final String OID = "oid";
+
+  private final RoleToAuthorityMapper roleToAuthorityMapper;
+
+  @Autowired
+  public JwtUserMapper(RoleToAuthorityMapper roleToAuthorityMapper) {
+    this.roleToAuthorityMapper = roleToAuthorityMapper;
+  }
 
   public IdTokenUserDetails createUser(Map<String, Object> decoded, String idToken) {
     return IdTokenUserDetails.builder()
@@ -33,17 +43,28 @@ public class JwtUserMapper {
     String value = (String) body.get(claimName);
     if (StringUtils.isEmpty(value)) {
       LOGGER.error("The JWT token is missing the claim '{}'", claimName);
-      throw new InsSecurityException("User is missing required claims");
+      throw missingRequiredClaims();
     }
     return value;
   }
 
-  private List<SimpleGrantedAuthority> getAuthorities(Map<String, Object> body) {
+  private List<GrantedAuthority> getAuthorities(Map<String, Object> body) {
     if (!body.containsKey("roles")) {
       LOGGER.error("The JWT token is missing the claim 'roles'");
-      throw new InsSecurityException("User is missing required claims");
+      throw missingRequiredClaims();
     }
-    List<String> roles = (List) body.get("roles");
-    return roles.stream().map(SimpleGrantedAuthority::new).collect(Collectors.toList());
+
+    Object rolesObj = body.get(ROLES);
+    if (!(rolesObj instanceof List)) {
+      LOGGER.error("The JWT token does not contain a list of 'roles'");
+      throw missingRequiredClaims();
+    }
+
+    List<String> roles = (List) rolesObj;
+    return roleToAuthorityMapper.mapRoles(roles);
+  }
+
+  private InsSecurityException missingRequiredClaims() {
+    return new InsSecurityException("User is missing required claims");
   }
 }

--- a/service/src/test/java/uk/gov/defra/tracesx/certificate/security/IdTokenAuthenticationTest.java
+++ b/service/src/test/java/uk/gov/defra/tracesx/certificate/security/IdTokenAuthenticationTest.java
@@ -7,6 +7,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.junit.Test;
+import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 
 public class IdTokenAuthenticationTest {
@@ -14,7 +15,7 @@ public class IdTokenAuthenticationTest {
   private static final String ID_TOKEN = "adfgsdf.dfgsdrgerg.dfgdfgd";
   private static final String USER_OBJECT_ID = "e9f6447d-2979-4322-8e52-307dafdef649";
   private static final List<String> ROLES = Arrays.asList("ROLE1", "ROLE2");
-  private static final List<SimpleGrantedAuthority> AUTHORITIES =
+  private static final List<GrantedAuthority> AUTHORITIES =
       Collections.unmodifiableList(
           ROLES.stream().map(SimpleGrantedAuthority::new).collect(Collectors.toList()));
 

--- a/service/src/test/java/uk/gov/defra/tracesx/certificate/security/RoleToAuthorityMapperTest.java
+++ b/service/src/test/java/uk/gov/defra/tracesx/certificate/security/RoleToAuthorityMapperTest.java
@@ -1,0 +1,32 @@
+package uk.gov.defra.tracesx.certificate.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+import java.util.List;
+import org.junit.Test;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+public class RoleToAuthorityMapperTest {
+
+  private RoleToAuthorityMapper mapper = new RoleToAuthorityMapper();
+
+  @Test
+  public void mapRole_inIdentityFormat_createOrganisationGrantedAuthority() {
+    List<String> roles = Arrays.asList("AD_ROLE", "organisation_id:identity_role:3");
+    List<GrantedAuthority> authorities = mapper.mapRoles(roles);
+    assertThat(authorities).hasSize(2);
+    assertThat(authorities.get(0))
+        .isInstanceOf(SimpleGrantedAuthority.class)
+        .isEqualTo(new SimpleGrantedAuthority("AD_ROLE"));
+    assertThat(authorities.get(1))
+        .isInstanceOf(OrganisationGrantedAuthority.class)
+        .isEqualTo(
+            OrganisationGrantedAuthority.builder()
+                .organisation("organisation_id")
+                .authority("identity_role")
+                .status("3")
+                .build());
+  }
+}


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | harsh vasudev (KAINOS) |
> | **GitLab Project** | [imports/certificate-microservice](https://giteux.azure.defra.cloud/imports/certificate-microservice) |
> | **GitLab Merge Request** | [IMTA-3489 Add support for three part rol...](https://giteux.azure.defra.cloud/imports/certificate-microservice/merge_requests/17) |
> | **GitLab MR Number** | [17](https://giteux.azure.defra.cloud/imports/certificate-microservice/merge_requests/17) |
> | **Date Originally Opened** | Wed, 19 Dec 2018 |
> | **Approved on GitLab by** | David McKinney (KAINOS), Ghost User, Lukasz Kedron (KAINOS) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Add support for three part roles used by identity