### PR TITLE
IMTA-3511 replacing name,upn,oid with sub as this is only common field in ad and b2c jwtokens

### DIFF
--- a/integration/src/main/java/uk/gov/defra/tracesx/integration/certificate/helpers/JwtConstants.java
+++ b/integration/src/main/java/uk/gov/defra/tracesx/integration/certificate/helpers/JwtConstants.java
@@ -4,9 +4,7 @@ public class JwtConstants {
 
   public static final String EXP = "exp";
   public static final String ROLES = "roles";
-  public static final String NAME = "name";
-  public static final String UPN = "upn";
-  public static final String OID = "oid";
+  public static final String SUB = "sub";
   public static final String BEARER = "Bearer ";
   public static final String AUD = "aud";
   public static final String ISS = "iss";

--- a/integration/src/main/java/uk/gov/defra/tracesx/integration/certificate/helpers/TokenHelper.java
+++ b/integration/src/main/java/uk/gov/defra/tracesx/integration/certificate/helpers/TokenHelper.java
@@ -53,9 +53,7 @@ public class TokenHelper {
     long exp = LocalDateTime.now().plusDays(1).toInstant(ZoneOffset.UTC).toEpochMilli() / 1000L;
     Map<String, Object> body = new HashMap<>(getClaims());
     body.put(EXP, exp);
-    body.put(NAME, "Test User");
-    body.put(UPN, "test.user@test-openid.com");
-    body.put(OID, "e48bb725-5fb2-4748-a858-9fabcc454092");
+    body.put(SUB, "e48bb725-5fb2-4748-a858-9fabcc454092");
     body.putAll(additionalClaims);
     try {
       return objectMapper.writeValueAsString(body);
@@ -69,9 +67,7 @@ public class TokenHelper {
     Map<String, Object> body = new HashMap<>(getClaims());
     body.put(ROLES, Collections.emptyList());
     body.put(EXP, exp);
-    body.put(NAME, "Test User");
-    body.put(UPN, "test.user@test-openid.com");
-    body.put(OID, "e48bb725-5fb2-4748-a858-9fabcc454092");
+    body.put(SUB, "e48bb725-5fb2-4748-a858-9fabcc454092");
     try {
       return objectMapper.writeValueAsString(body);
     } catch (JsonProcessingException e) {

--- a/service/src/main/java/uk/gov/defra/tracesx/certificate/security/jwt/JwtUserMapper.java
+++ b/service/src/main/java/uk/gov/defra/tracesx/certificate/security/jwt/JwtUserMapper.java
@@ -18,9 +18,7 @@ import uk.gov.defra.tracesx.certificate.security.RoleToAuthorityMapper;
 public class JwtUserMapper {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(JwtUserMapper.class);
-  public static final String NAME = "name";
-  public static final String UPN = "upn";
-  public static final String OID = "oid";
+  public static final String SUB = "sub";
 
   private final RoleToAuthorityMapper roleToAuthorityMapper;
 
@@ -29,12 +27,14 @@ public class JwtUserMapper {
     this.roleToAuthorityMapper = roleToAuthorityMapper;
   }
 
+  //FIXME: at the moment ad jwt and b2c jwt have only one common field which is sub.
+  // It was decided for now sub will be used to poulate following data.
   public IdTokenUserDetails createUser(Map<String, Object> decoded, String idToken) {
     return IdTokenUserDetails.builder()
         .idToken(idToken)
-        .displayName(getRequiredClaim(NAME, decoded))
-        .username(getRequiredClaim(UPN, decoded))
-        .userObjectId(getRequiredClaim(OID, decoded))
+        .displayName(getRequiredClaim(SUB, decoded))
+        .username(getRequiredClaim(SUB, decoded))
+        .userObjectId(getRequiredClaim(SUB, decoded))
         .authorities(getAuthorities(decoded))
         .build();
   }

--- a/service/src/test/java/uk/gov/defra/tracesx/certificate/security/JwtUserMapperTest.java
+++ b/service/src/test/java/uk/gov/defra/tracesx/certificate/security/JwtUserMapperTest.java
@@ -28,9 +28,7 @@ public class JwtUserMapperTest {
   private JwtUserMapper jwtUserMapper = new JwtUserMapper(roleToAuthorityMapper);
 
   private static final String ID_TOKEN = "adfgsdf.dfgsdrgerg.dfgdfgd";
-  private static final String USER_OBJECT_ID = "e9f6447d-2979-4322-8e52-307dafdef649";
-  private static final String DISPLAY_NAME = "Joseph William Token";
-  private static final String USERNAME = "jtoken@tenant.com";
+  private static final String SUB = "e9f6447d-2979-4322-8e52-307dafdef649";
   private static final List<String> ROLES = Arrays.asList("ROLE1", "ROLE2");
   private static final List<GrantedAuthority> AUTHORITIES =
       Collections.unmodifiableList(
@@ -39,9 +37,7 @@ public class JwtUserMapperTest {
   @Before
   public void before() {
     decoded = new HashMap<>();
-    decoded.put("oid", USER_OBJECT_ID);
-    decoded.put("name", DISPLAY_NAME);
-    decoded.put("upn", USERNAME);
+    decoded.put("sub", SUB);
     decoded.put("roles", ROLES);
   }
 
@@ -52,9 +48,9 @@ public class JwtUserMapperTest {
         IdTokenUserDetails.builder()
             .idToken(ID_TOKEN)
             .authorities(AUTHORITIES)
-            .userObjectId(USER_OBJECT_ID)
-            .displayName(DISPLAY_NAME)
-            .username(USERNAME)
+            .userObjectId(SUB)
+            .displayName(SUB)
+            .username(SUB)
             .build();
     assertThat(user).isEqualTo(expected);
   }
@@ -67,7 +63,7 @@ public class JwtUserMapperTest {
   }
 
   @DataPoints("API Methods")
-  public static final String[] missingClaims = new String[] {"oid", "name", "upn", "roles"};
+  public static final String[] missingClaims = new String[] {"sub", "roles"};
 
   @Theory
   public void createUser_fromIncompleteClaims_throwsException(String missingClaim) {


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | Lukasz Kedron (KAINOS) |
> | **GitLab Project** | [imports/certificate-microservice](https://giteux.azure.defra.cloud/imports/certificate-microservice) |
> | **GitLab Merge Request** | [IMTA-3511 replacing name,upn,oid with su...](https://giteux.azure.defra.cloud/imports/certificate-microservice/merge_requests/19) |
> | **GitLab MR Number** | [19](https://giteux.azure.defra.cloud/imports/certificate-microservice/merge_requests/19) |
> | **Date Originally Opened** | Sat, 22 Dec 2018 |
> | **Approved on GitLab by** | Usman Shabbir, iwan roberts (KAINOS) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

_No description_