### PR TITLE
IMTA-5479 Allow blank certificates

### DIFF
--- a/service/src/main/java/uk/gov/defra/tracesx/certificate/utils/ReferenceNumberGenerator.java
+++ b/service/src/main/java/uk/gov/defra/tracesx/certificate/utils/ReferenceNumberGenerator.java
@@ -9,7 +9,7 @@ import java.util.regex.Pattern;
 public class ReferenceNumberGenerator {
 
   private static final Pattern PATTERN =
-      Pattern.compile("(CVEDA|CED|CVEDP|DRAFT).GB.20\\d{2}.\\d{7,8}");
+      Pattern.compile("((CVEDA|CED|CVEDP|DRAFT).GB.20\\d{2}.\\d{7,8})|(CVEDA|CED|CVEDP)");
 
   private final String referenceNumber;
 

--- a/service/src/test/java/uk/gov/defra/tracesx/certificate/resource/ReferenceNumberGeneratorTest.java
+++ b/service/src/test/java/uk/gov/defra/tracesx/certificate/resource/ReferenceNumberGeneratorTest.java
@@ -8,12 +8,33 @@ import uk.gov.defra.tracesx.certificate.utils.exception.InvalidReferenceNumberEx
 
 public class ReferenceNumberGeneratorTest {
 
+  private final String CVEDA_BLANK_REFERENCE = "CVEDA";
+  private final String CVEDP_BLANK_REFERENCE = "CVEDP";
+  private final String CED_BLANK_REFERENCE = "CED";
   private final String CVEDA_REFERENCE = "CVEDA.GB.2018.12345678";
   private final String CVEDP_REFERENCE = "CVEDP.GB.2018.1234567";
   private final String CED_REFERENCE = "CED.GB.2018.1234567";
   private final String DRAFT_REFERENCE = "DRAFT.GB.2018.1234567";
   private final String INVALID_REFERENCE_REF_NUM_BREACH_TOO_LONG = "CVEDA.GB.2018.12345678213123";
   private final String INVALID_REFERENCE_REF_NUM_BREACH_TOO_SHORT = "CVEDP.GB.2018.123";
+
+  @Test
+  public void shouldCreateReferenceNumberForCVEDA_WhenBlank() {
+    assertThat(ReferenceNumberGenerator.valueOf(CVEDA_BLANK_REFERENCE).valueOf())
+        .isEqualTo(CVEDA_BLANK_REFERENCE);
+  }
+
+  @Test
+  public void shouldCreateReferenceNumberForCVEDP_WhenBlank() {
+    assertThat(ReferenceNumberGenerator.valueOf(CVEDP_BLANK_REFERENCE).valueOf())
+        .isEqualTo(CVEDP_BLANK_REFERENCE);
+  }
+
+  @Test
+  public void shouldCreateReferenceNumberForCED_WhenBlank() {
+    assertThat(ReferenceNumberGenerator.valueOf(CED_BLANK_REFERENCE).valueOf())
+        .isEqualTo(CED_BLANK_REFERENCE);
+  }
 
   @Test
   public void shouldCreateReferenceNumberForCVEDA() {
@@ -40,7 +61,7 @@ public class ReferenceNumberGeneratorTest {
   }
 
   @Test
-  public void shouldSupportToString() throws Exception {
+  public void shouldSupportToString() {
     assertThat(ReferenceNumberGenerator.valueOf(CVEDA_REFERENCE).toString())
         .isEqualTo("ReferenceNumberGenerator(CVEDA.GB.2018.12345678)");
   }
@@ -53,26 +74,26 @@ public class ReferenceNumberGeneratorTest {
   }
 
   @Test
-  public void shouldThrowExceptionIfNull() throws Exception {
+  public void shouldThrowExceptionIfNull() {
     assertThatThrownBy(() -> ReferenceNumberGenerator.valueOf(null))
         .isInstanceOf(InvalidReferenceNumberException.class);
   }
 
   @Test
-  public void shouldThrowExceptionIfEmpty() throws Exception {
+  public void shouldThrowExceptionIfEmpty() {
     assertThatThrownBy(() -> ReferenceNumberGenerator.valueOf(""))
         .isInstanceOf(InvalidReferenceNumberException.class);
   }
 
   @Test
-  public void shouldThrowExceptionIfBlank() throws Exception {
+  public void shouldThrowExceptionIfBlank() {
     assertThatThrownBy(() -> ReferenceNumberGenerator.valueOf("   "))
         .isInstanceOf(InvalidReferenceNumberException.class);
 
   }
 
   @Test
-  public void shouldThrowExceptionIfRangeBreached() throws Exception {
+  public void shouldThrowExceptionIfRangeBreached() {
     assertThatThrownBy(() -> ReferenceNumberGenerator.valueOf(INVALID_REFERENCE_REF_NUM_BREACH_TOO_LONG))
         .isInstanceOf(InvalidReferenceNumberException.class);
 


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | Stephen Donaghey (KAINOS) |
> | **GitLab Project** | [imports/certificate-microservice](https://giteux.azure.defra.cloud/imports/certificate-microservice) |
> | **GitLab Merge Request** | [IMTA-5479 Allow blank certificates](https://giteux.azure.defra.cloud/imports/certificate-microservice/merge_requests/39) |
> | **GitLab MR Number** | [39](https://giteux.azure.defra.cloud/imports/certificate-microservice/merge_requests/39) |
> | **Date Originally Opened** | Wed, 14 Aug 2019 |
> | **Approved on GitLab by** | Sean Treanor (KAINOS), iwan roberts (KAINOS), marcus bond (KAINOS) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Allowed CVEDA, CVEDP and CED to be reference numbers for blank certificate generation.