### PR TITLE
[EUXO-1003] Update Base Image for internal SSL Certificates

### DIFF
--- a/service/Dockerfile
+++ b/service/Dockerfile
@@ -1,4 +1,6 @@
-FROM sndeuxfesacr001.azurecr.io/java-20191011:alpine3.10.2-javaJRE11
+ARG BASE_IMAGE
+
+FROM sndeuxfesacr001.azurecr.io/$BASE_IMAGE
 
 RUN mkdir -p /usr/src/certificate-service
 WORKDIR /usr/src/certificate-service


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | Alan Warnock |
> | **GitLab Project** | [imports/certificate-microservice](https://giteux.azure.defra.cloud/imports/certificate-microservice) |
> | **GitLab Merge Request** | [[EUXO-1003] Update Base Image for intern...](https://giteux.azure.defra.cloud/imports/certificate-microservice/merge_requests/44) |
> | **GitLab MR Number** | [44](https://giteux.azure.defra.cloud/imports/certificate-microservice/merge_requests/44) |
> | **Date Originally Opened** | Thu, 7 Nov 2019 |
> | **Approved on GitLab by** | Ghost User, Lynn Eagleton (KAINOS), Stephen Donaghey (KAINOS) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

+ Update dockerfile to use new java base image