### PR TITLE
IMTA-6780: Set the sonar properties to report code coverage

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,5 +6,4 @@ javaPipeline {
     SERVICE_VERSION = "1.0"
     ENVIRONMENT = "Sandpit"
     SELENIUM_BRANCH = "master"
-    JAVA_VERSION = "11"
 }

--- a/runJunit.sh
+++ b/runJunit.sh
@@ -1,2 +1,3 @@
 #!/bin/sh
-mvn test -f service/pom.xml --settings service/vs-maven.xml -Dmaven.repo.local=${WORKSPACE}/.m2
+export JAVA_HOME=$JAVA_HOME_11
+mvn clean test jacoco:report -f service/pom.xml --settings service/vs-maven.xml -Dmaven.repo.local=${WORKSPACE}/.m2

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,7 +1,12 @@
 sonar.projectKey=Imports-MS-Certificate
-#By default include everything, use specific exclusions
-sonar.exclusions=database/**,integration/**,resources/**,target/**,service/src/test/**
-sonar.coverage.exclusions=**
-sonar.java.binaries=.
-sonar.sources=.
-sonar.java.source=1.8
+
+sonar.java.binaries=service/target/classes
+sonar.java.test.binaries=service/target/test-classes
+sonar.sources=service/src/main/java
+sonar.tests=service/src/test/java
+sonar.java.source=11
+sonar.sourceEncoding=UTF-8
+sonar.coverage.jacoco.xmlReportPaths=service/target/site/jacoco/jacoco.xml
+sonar.dynamicAnalysis=reuseReports
+sonar.junit.reportPaths=service/target/surefire-reports/
+


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | marcus bond (KAINOS) |
> | **GitLab Project** | [imports/certificate-microservice](https://giteux.azure.defra.cloud/imports/certificate-microservice) |
> | **GitLab Merge Request** | [IMTA-6780: Set the sonar properties to r...](https://giteux.azure.defra.cloud/imports/certificate-microservice/merge_requests/51) |
> | **GitLab MR Number** | [51](https://giteux.azure.defra.cloud/imports/certificate-microservice/merge_requests/51) |
> | **Date Originally Opened** | Wed, 11 Mar 2020 |
> | **Approved on GitLab by** | Ghost User, Reece Bennett (KAINOS), daniel brennan (KAINOS) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

IMTA-6780: Set the sonar properties to report code coverage

https://eaflood.atlassian.net/browse/IMTA-6780
