### PR TITLE
IMTA-7773 Removing line to prevent 400 bad request errors

### DIFF
--- a/service/src/main/java/uk/gov/defra/tracesx/certificate/utils/HtmlValidator.java
+++ b/service/src/main/java/uk/gov/defra/tracesx/certificate/utils/HtmlValidator.java
@@ -24,7 +24,6 @@ public class HtmlValidator {
       dbFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
       dbFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
       dbFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
-      dbFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
       dbFactory.setFeature("http://xml.org/sax/features/external-general-entities", false);
       dbFactory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
       dbFactory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | David McKinney (KAINOS) |
> | **GitLab Project** | [imports/certificate-microservice](https://giteux.azure.defra.cloud/imports/certificate-microservice) |
> | **GitLab Merge Request** | [IMTA-7773 Removing line to prevent 400 b...](https://giteux.azure.defra.cloud/imports/certificate-microservice/merge_requests/59) |
> | **GitLab MR Number** | [59](https://giteux.azure.defra.cloud/imports/certificate-microservice/merge_requests/59) |
> | **Date Originally Opened** | Thu, 23 Jul 2020 |
> | **Approved on GitLab by** | Holmes, Nathanael (Kainos), Reece Bennett (KAINOS), Sean Treanor (KAINOS), iwan roberts (KAINOS), kamil mojek (KAINOS) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Error was found after putting in security features recommended by OWASP to prevent XEE injection
https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html#Java

-DOCTYPE is disallowed when the feature http://apache.org/xml/features/disallow-doctype-dec set to true

Fixes the 400s on certificate viewing and sonarqube reports 0 new vulnerabilities