### PR TITLE
IMTA-8281 - removed NI (XI) from regex and updated tests

### DIFF
--- a/integration/src/test/java/uk/gov/defra/tracesx/certificate/integration/CertificateServiceTest.java
+++ b/integration/src/test/java/uk/gov/defra/tracesx/certificate/integration/CertificateServiceTest.java
@@ -32,13 +32,13 @@ public class CertificateServiceTest {
   }
 
   @Test
-  public void shouldCreateCertificateFromHtmlForXI() {
+  public void shouldReturnBadRequestCreateCertificateFromHtmlForXI() {
 
     String htmlContent = "<p>hello world</p>";
     String callBackUrl = "";
     Response response = certificateApi.getPdf(htmlContent, REFERENCE_XI, callBackUrl);
 
-    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.SC_OK);
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.SC_BAD_REQUEST);
   }
 
   @Test

--- a/service/src/main/java/uk/gov/defra/tracesx/certificate/utils/ReferenceNumberGenerator.java
+++ b/service/src/main/java/uk/gov/defra/tracesx/certificate/utils/ReferenceNumberGenerator.java
@@ -13,8 +13,7 @@ public class ReferenceNumberGenerator {
   private static final Logger LOGGER = LoggerFactory.getLogger(ReferenceNumberGenerator.class);
   private static final Pattern PATTERN =
       Pattern.compile(
-          "((CHEDA|CHEDD|CHEDPP|CHEDP|DRAFT).(GB|XI).20\\d{2}.\\d{7,8})|"
-                  + "(CHEDA|CHEDD|CHEDPP|CHEDP)");
+              "((CHEDA|CHEDD|CHEDPP|CHEDP|DRAFT).GB.20\\d{2}.\\d{7,8})|(CHEDA|CHEDD|CHEDPP|CHEDP)");
 
   private final String referenceNumber;
 

--- a/service/src/test/java/uk/gov/defra/tracesx/certificate/resource/ReferenceNumberGeneratorTest.java
+++ b/service/src/test/java/uk/gov/defra/tracesx/certificate/resource/ReferenceNumberGeneratorTest.java
@@ -12,6 +12,7 @@ public class ReferenceNumberGeneratorTest {
   private final String CVEDA_REFERENCE = "CHEDA.GB.2018.12345678";
   private final String INVALID_REFERENCE_REF_NUM_BREACH_TOO_LONG = "CHEDA.GB.2018.12345678213123";
   private final String INVALID_REFERENCE_REF_NUM_BREACH_TOO_SHORT = "CHEDP.GB.2018.123";
+  private final String CVEDP_REFERENCE_XI = "CHEDP.XI.2018.1234567";
 
   @Test
   public void shouldCreateReferenceNumberForCVEDA_WhenBlank() {
@@ -117,9 +118,9 @@ public class ReferenceNumberGeneratorTest {
   }
 
   @Test
-  public void shouldCreateReferenceNumberForXI() {
-    String CVEDP_REFERENCE = "CHEDP.XI.2018.1234567";
-    assertThat(ReferenceNumberGenerator.valueOf(CVEDP_REFERENCE).valueOf())
-            .isEqualTo(CVEDP_REFERENCE);
+  public void shouldThrowExceptionForXI() {
+    assertThatThrownBy(
+            () -> ReferenceNumberGenerator.valueOf(CVEDP_REFERENCE_XI))
+            .isInstanceOf(InvalidReferenceNumberException.class);
   }
 }


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | Robert Hall (KAINOS) |
> | **GitLab Project** | [imports/certificate-microservice](https://giteux.azure.defra.cloud/imports/certificate-microservice) |
> | **GitLab Merge Request** | [IMTA-8281 - removed NI (XI) from regex a...](https://giteux.azure.defra.cloud/imports/certificate-microservice/merge_requests/64) |
> | **GitLab MR Number** | [64](https://giteux.azure.defra.cloud/imports/certificate-microservice/merge_requests/64) |
> | **Date Originally Opened** | Fri, 18 Sep 2020 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **closed** on GitLab

## Original Description

Removed regex to accept XI and updated unit and integration tests