### PR TITLE
IMTA-8281 - removed NI (XI) from regex and updated tests

### DIFF
--- a/integration/src/test/java/uk/gov/defra/tracesx/certificate/integration/CertificateServiceTest.java
+++ b/integration/src/test/java/uk/gov/defra/tracesx/certificate/integration/CertificateServiceTest.java
@@ -15,7 +15,6 @@ import org.springframework.test.context.junit4.SpringRunner;
 public class CertificateServiceTest {
 
   private final String REFERENCE = "CHEDA.GB.2018.1234567";
-  private final String REFERENCE_XI = "CHEDA.XI.2018.1234567";
   private final String REFERENCE_INVALID = "CHEDA.INVALID.2018.1234567";
 
   @Autowired
@@ -27,16 +26,6 @@ public class CertificateServiceTest {
     String htmlContent = "<p>hello world</p>";
     String callBackUrl = "";
     Response response = certificateApi.getPdf(htmlContent, REFERENCE, callBackUrl);
-
-    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.SC_OK);
-  }
-
-  @Test
-  public void shouldCreateCertificateFromHtmlForXI() {
-
-    String htmlContent = "<p>hello world</p>";
-    String callBackUrl = "";
-    Response response = certificateApi.getPdf(htmlContent, REFERENCE_XI, callBackUrl);
 
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.SC_OK);
   }

--- a/service/src/main/java/uk/gov/defra/tracesx/certificate/utils/ReferenceNumberGenerator.java
+++ b/service/src/main/java/uk/gov/defra/tracesx/certificate/utils/ReferenceNumberGenerator.java
@@ -13,8 +13,7 @@ public class ReferenceNumberGenerator {
   private static final Logger LOGGER = LoggerFactory.getLogger(ReferenceNumberGenerator.class);
   private static final Pattern PATTERN =
       Pattern.compile(
-          "((CHEDA|CHEDD|CHEDPP|CHEDP|DRAFT).(GB|XI).20\\d{2}.\\d{7,8})|"
-                  + "(CHEDA|CHEDD|CHEDPP|CHEDP)");
+              "((CHEDA|CHEDD|CHEDPP|CHEDP|DRAFT).GB.20\\d{2}.\\d{7,8})|(CHEDA|CHEDD|CHEDPP|CHEDP)");
 
   private final String referenceNumber;
 

--- a/service/src/test/java/uk/gov/defra/tracesx/certificate/resource/ReferenceNumberGeneratorTest.java
+++ b/service/src/test/java/uk/gov/defra/tracesx/certificate/resource/ReferenceNumberGeneratorTest.java
@@ -115,11 +115,4 @@ public class ReferenceNumberGeneratorTest {
             () -> ReferenceNumberGenerator.valueOf(INVALID_REFERENCE_REF_NUM_BREACH_TOO_SHORT))
         .isInstanceOf(InvalidReferenceNumberException.class);
   }
-
-  @Test
-  public void shouldCreateReferenceNumberForXI() {
-    String CVEDP_REFERENCE = "CHEDP.XI.2018.1234567";
-    assertThat(ReferenceNumberGenerator.valueOf(CVEDP_REFERENCE).valueOf())
-            .isEqualTo(CVEDP_REFERENCE);
-  }
 }


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | Robert Hall (KAINOS) |
> | **GitLab Project** | [imports/certificate-microservice](https://giteux.azure.defra.cloud/imports/certificate-microservice) |
> | **GitLab Merge Request** | [IMTA-8281 - removed NI (XI) from regex a...](https://giteux.azure.defra.cloud/imports/certificate-microservice/merge_requests/65) |
> | **GitLab MR Number** | [65](https://giteux.azure.defra.cloud/imports/certificate-microservice/merge_requests/65) |
> | **Date Originally Opened** | Mon, 21 Sep 2020 |
> | **Approved on GitLab by** | Althaf Azeez (KAINOS), Stephen McVeigh, dominik henjes (KAINOS), iwan roberts (KAINOS) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

_No description_