### PR TITLE
[IMTA-4568] Adding LANG attribute to identify the language in the PDF/Page -Initial commit

### DIFF
--- a/service/src/main/java/uk/gov/defra/tracesx/certificate/utils/Sanitizer.java
+++ b/service/src/main/java/uk/gov/defra/tracesx/certificate/utils/Sanitizer.java
@@ -15,6 +15,7 @@ public class Sanitizer {
       .allowAttributes("href", "rel").onElements("link")
       .allowAttributes("colspan").globally()
       .allowAttributes("class").globally()
+      .allowAttributes("lang").onElements("html")
       .toFactory()
       .and(Sanitizers.FORMATTING)
       .and(Sanitizers.IMAGES)

--- a/service/src/test/java/uk/gov/defra/tracesx/certificate/resource/SanitizerTest.java
+++ b/service/src/test/java/uk/gov/defra/tracesx/certificate/resource/SanitizerTest.java
@@ -42,6 +42,17 @@ public class SanitizerTest {
   }
 
   @Test
+  public void shouldAllowLanguageAttributeInHtml() {
+    String html = ""
+            + "<html lang=\"en\">"
+            + "<head>"
+            + "<link href=\"/public/stylesheets/certificate.css\" rel=\"stylesheet\" />"
+            + "</head>"
+            + "</html>";
+    validateUnchanged(html);
+  }
+
+  @Test
   public void shouldAllowColspanOnRows() {
     String html = ""
         + "<table>"


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | Praveen Gajula (KAINOS) |
> | **GitLab Project** | [imports/certificate-microservice](https://giteux.azure.defra.cloud/imports/certificate-microservice) |
> | **GitLab Merge Request** | [[IMTA-4568] Adding LANG attribute to ide...](https://giteux.azure.defra.cloud/imports/certificate-microservice/merge_requests/69) |
> | **GitLab MR Number** | [69](https://giteux.azure.defra.cloud/imports/certificate-microservice/merge_requests/69) |
> | **Date Originally Opened** | Tue, 3 Nov 2020 |
> | **Approved on GitLab by** | Althaf Azeez (KAINOS), Kamesh Ganesan (KAINOS), Stephen McVeigh, daniel brennan (KAINOS), marcus bond (KAINOS) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

_No description_