### PR TITLE
IMTA-13157:add pre-commit hook for linting

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ It is used as a pre-push hook and will scan any local commits being pushed
 1. Install [truffleHog](https://github.com/trufflesecurity/truffleHog)
     - `pip3 install --trusted-host pypi.org --trusted-host files.pythonhosted.org truffleHog` (might require sudo privileges)
 2. Set DEFRA_WORKSPACE env var (`export DEFRA_WORKSPACE=/path/to/workspace`)
-3. Copy the pre-push hook to your .git hooks folder or run `git config core.hooksPath hooks`
+3. Run `mvn install` to configure hooks
 
 ## Set up
 Ensure that you have the necessary configuration to resolve dependencies from Artifactory: https://eaflood.atlassian.net/wiki/spaces/IT/pages/1047823027/Artifactory

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+RED='\033[0;31m'
+NO_COLOUR='\033[0m'
+LOG_PREFIX="Pre-commit hook:"
+FAILED_MESSAGE="${LOG_PREFIX} ${RED}[FAILED]${NO_COLOUR}"
+
+cd service || exit
+echo "${LOG_PREFIX} Running Checkstyle"
+
+if mvn checkstyle:check; then
+  echo "${LOG_PREFIX} OK proceeding with commit"
+  exit 0
+else
+  echo -e "${FAILED_MESSAGE} git commit failed, address Checkstyle violations"
+  exit 1
+fi

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>uk.gov.defra.tracesx</groupId>
     <artifactId>spring-boot-parent</artifactId>
-    <version>2.0.217</version>
+    <version>2.0.224</version>
   </parent>
 
   <properties>


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | Odran Muldoon (Kainos) |
> | **GitLab Project** | [imports/certificate-microservice](https://giteux.azure.defra.cloud/imports/certificate-microservice) |
> | **GitLab Merge Request** | [IMTA-13157:add pre-commit hook for linti...](https://giteux.azure.defra.cloud/imports/certificate-microservice/merge_requests/92) |
> | **GitLab MR Number** | [92](https://giteux.azure.defra.cloud/imports/certificate-microservice/merge_requests/92) |
> | **Date Originally Opened** | Mon, 9 Jan 2023 |
> | **Approved on GitLab by** | Apurva Jhunjhunwala (Kainos), Eugene Fahy (Kainos), Marina Tihova, Reece Bennett (KAINOS) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

### :link: [Jira Ticket](https://eaflood.atlassian.net/browse/IMTA-13157)

### :chart_with_upwards_trend: [SonarQube Report](https://vss-sonarqube.azure.defra.cloud/dashboard?branch=feature%2FIMTA-13157-adding-pre-commit-git-hook-for-linting&id=Imports-MS-Certificate)

### :building_construction: [Jenkins Pipeline](https://jenkins-imports.azure.defra.cloud/job/certificate-microservice/job/feature%2FIMTA-13157-adding-pre-commit-git-hook-for-linting/)

### :book: Changes:

- bump Spring Boot parent to 2.0.224
- added pre-commit script for Checkstyle