### PR TITLE
IMTA-18896 - Remove basic auth from the permissions service 2b/5

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The Certificate service API is written using the Spring Boot framework and has b
 
 In order to run the service you will need the following dependencies
 
-- JDK v11
+- JDK v17
 - Maven v3
 
 ## Secret scanning
@@ -69,7 +69,6 @@ The following properties are used by the application (see required values in the
 
 ```
 SERVICE_PORT
-PERMISSIONS_SERVICE_PASSWORD
 PROTOCOL
 SECURITY_JWT_JWKS
 SECURITY_JWT_ISS
@@ -111,7 +110,6 @@ You should only need to do this for the first time you pull the base image. In c
 ### Environment variables 
 ```
 export SERVICE_PORT=6060
-export PERMISSIONS_SERVICE_PASSWORD=${SERVICE_PASSWORD}
 export PROTOCOL=https
 export SECURITY_JWT_JWKS
 export SECURITY_JWT_ISS

--- a/integration/README.md
+++ b/integration/README.md
@@ -4,6 +4,12 @@
 
 This project is a standalone maven project for running automated integration tests.
 
+## Pre-requisites
+
+- JDK v17
+- Maven v3
+- [Lombok Plugin](https://plugins.jetbrains.com/plugin/6317-lombok-plugin) (only required for development)
+
 ## How To Run
 
 Before running the tests start up the service as per the root README

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -13,7 +13,7 @@
   <parent>
     <groupId>uk.gov.defra.tracesx</groupId>
     <artifactId>spring-boot-parent</artifactId>
-    <version>4.0.42</version>
+    <version>4.0.43</version>
   </parent>
 
   <properties>

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -40,8 +40,6 @@ spring:
 permissions:
   service:
     url: ${PROTOCOL}://permissions${ENV_DOMAIN}
-    user: importer
-    password: ${PERMISSIONS_SERVICE_PASSWORD}
     connectionTimeout: 3000
     readTimeout: 3000
   security:


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | Ajith Thomas (Kainos) |
> | **GitLab Project** | [imports/certificate-microservice](https://giteux.azure.defra.cloud/imports/certificate-microservice) |
> | **GitLab Merge Request** | [IMTA-18896 - Remove basic auth from the ...](https://giteux.azure.defra.cloud/imports/certificate-microservice/merge_requests/111) |
> | **GitLab MR Number** | [111](https://giteux.azure.defra.cloud/imports/certificate-microservice/merge_requests/111) |
> | **Date Originally Opened** | Wed, 23 Oct 2024 |
> | **Approved on GitLab by** | @trinhchuongee, Lewis Birks (Kainos), Martin Willitts (Kainos), Łukasz Pietrynczak (Kainos) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

### :link: [Jira Ticket](https://eaflood.atlassian.net/browse/IMTA-18896)

### :chart_with_upwards_trend: [SonarQube Report](https://vss-sonarqube.azure.defra.cloud/dashboard?branch=feature%2FIMTA-18896-remove-basic-auth&id=Imports-MS-Certificate)

### :building_construction: [Jenkins Pipeline](https://jenkins-imports.azure.defra.cloud/job/certificate-microservice/job/feature%2FIMTA-18896-remove-basic-auth/)

### :white_check_mark: Green Selenium Test:

https://jenkins-imports.azure.defra.cloud/view/Tests/job/Run_Selenium_Tests/9613/

### :book: Changes:

- Remove Basic Auth for Permissions