### PR TITLE
IMTA-19310 remove vulnerability in spring-security-web

### DIFF
--- a/service/pom.xml
+++ b/service/pom.xml
@@ -12,8 +12,8 @@
 
   <parent>
     <groupId>uk.gov.defra.tracesx</groupId>
-    <artifactId>spring-boot-parent</artifactId>
-    <version>4.0.47</version>
+    <artifactId>TracesX-SpringBoot-Common-Parent</artifactId>
+    <version>4.0.6</version>
   </parent>
 
   <properties>
@@ -51,6 +51,14 @@
     <dependency>
       <groupId>uk.gov.defra.tracesx</groupId>
       <artifactId>TracesX-SpringBoot-Common-Health</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>uk.gov.defra.tracesx</groupId>
+      <artifactId>TracesX-SpringBoot-Common-Logging</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>uk.gov.defra.tracesx</groupId>
+      <artifactId>TracesX-SpringBoot-Common-Security</artifactId>
     </dependency>
     <dependency>
       <groupId>com.googlecode.owasp-java-html-sanitizer</groupId>


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | @crosslandwa |
> | **GitLab Project** | [imports/certificate-microservice](https://giteux.azure.defra.cloud/imports/certificate-microservice) |
> | **GitLab Merge Request** | [IMTA-19310 remove vulnerability in sprin...](https://giteux.azure.defra.cloud/imports/certificate-microservice/merge_requests/116) |
> | **GitLab MR Number** | [116](https://giteux.azure.defra.cloud/imports/certificate-microservice/merge_requests/116) |
> | **Date Originally Opened** | Mon, 10 Feb 2025 |
> | **Approved on GitLab by** | @dannyjo |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

update to latest TracesX-SpringBoot-Common-Parent (which updates underlying Spring Boot version)

also add direct dependencies on
- TracesX-SpringBoot-Common-Health
- TracesX-SpringBoot-Common-Logging
- TracesX-SpringBoot-Common-Security
(these used to be brought in as dependencies by the previous parent POM)