### PR TITLE
IMTA-12898 : Phase 4 - Azure Default Ports

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-@Library('pipeline-library') _
+@Library('pipeline-library@feature/IMTA-12898-azure-default-port') _
 
 javaPipeline {
     SERVICE_NAME = "certificate-microservice"

--- a/service/Dockerfile
+++ b/service/Dockerfile
@@ -13,6 +13,6 @@ COPY lib/applicationinsights.json /usr/src/certificate-service/
 RUN chown jreuser /usr/src/certificate-service
 USER jreuser
 
-EXPOSE 4000
+EXPOSE 8080
 
 CMD ["java", "-javaagent:/usr/src/certificate-service/applicationinsights-agent.jar", "-jar", "TracesX_Certificate.jar"]


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | prabash balasuriya (kainos) |
> | **GitLab Project** | [imports/certificate-microservice](https://giteux.azure.defra.cloud/imports/certificate-microservice) |
> | **GitLab Merge Request** | [IMTA-12898 : Phase 4 - Azure Default Por...](https://giteux.azure.defra.cloud/imports/certificate-microservice/merge_requests/89) |
> | **GitLab MR Number** | [89](https://giteux.azure.defra.cloud/imports/certificate-microservice/merge_requests/89) |
> | **Date Originally Opened** | Mon, 31 Oct 2022 |
> | **Approved on GitLab by** | Blakeley, Paul (Kainos), Reece Bennett (KAINOS), Stephen Donaghey (KAINOS), ramkumar ramagopal (Kainos) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

### :link: [Jira Ticket](https://eaflood.atlassian.net/browse/IMTA-12898)

### :chart_with_upwards_trend: [SonarQube Report](https://vss-sonarqube.azure.defra.cloud/dashboard?branch=feature%2FIMTA-12898-azure-default-port&id=Imports-MS-Certificate)

### :building_construction: [Jenkins Pipeline](https://jenkins-imports.azure.defra.cloud/job/certificate-microservice/job/feature%2FIMTA-12898-azure-default-port/)

### :book: Changes:
* Use port 8080

### :white_check_mark: Selenium Test Run:

PENDING