### PR TITLE
IMTA-9652/9600: Vulnerabilities and unused dependencies

### DIFF
--- a/integration/pom.xml
+++ b/integration/pom.xml
@@ -44,6 +44,11 @@
           </argLine>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <version>3.1.2</version>
+      </plugin>
     </plugins>
   </build>
   <dependencies>
@@ -65,10 +70,6 @@
       <groupId>org.springframework</groupId>
       <artifactId>spring-test</artifactId>
       <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.github.javafaker</groupId>
-      <artifactId>javafaker</artifactId>
     </dependency>
   </dependencies>
     <name>TracesX-Certificate-Integration</name>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -13,12 +13,13 @@
   <parent>
     <groupId>uk.gov.defra.tracesx</groupId>
     <artifactId>spring-boot-parent</artifactId>
-    <version>2.0.116</version>
+    <version>2.0.153</version>
   </parent>
 
   <properties>
-    <openhtml.version>1.0.1</openhtml.version>
+    <openhtml.version>1.0.8</openhtml.version>
     <owasp-java-html-sanitizer.version>20181114.1</owasp-java-html-sanitizer.version>
+    <commons-io.version>2.10.0</commons-io.version>
   </properties>
 
   <dependencyManagement>
@@ -37,6 +38,11 @@
         <groupId>com.openhtmltopdf</groupId>
         <artifactId>openhtmltopdf-pdfbox</artifactId>
         <version>${openhtml.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>commons-io</groupId>
+        <artifactId>commons-io</artifactId>
+        <version>${commons-io.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -61,6 +67,10 @@
     <dependency>
       <groupId>com.openhtmltopdf</groupId>
       <artifactId>openhtmltopdf-pdfbox</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | Kelly Moore |
> | **GitLab Project** | [imports/certificate-microservice](https://giteux.azure.defra.cloud/imports/certificate-microservice) |
> | **GitLab Merge Request** | [IMTA-9652/9600: Vulnerabilities and unus...](https://giteux.azure.defra.cloud/imports/certificate-microservice/merge_requests/72) |
> | **GitLab MR Number** | [72](https://giteux.azure.defra.cloud/imports/certificate-microservice/merge_requests/72) |
> | **Date Originally Opened** | Thu, 17 Jun 2021 |
> | **Approved on GitLab by** | Holmes, Nathanael (Kainos), Juliano Saunders (Kainos), iwan roberts (KAINOS), kamil mojek (KAINOS) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

IMTA-9652: Addressing vulnerabilities - Upgrade spring-boot-parent, IMTA-9600: Remove used dependencies

### :link: tickets: https://eaflood.atlassian.net/browse/IMTA-9652 & https://eaflood.atlassian.net/browse/IMTA-9600
### :book: Changes:
* Upgraded spring-boot-parent: Resolves vulnerabilities in tomcat-embed-core
* Upgraded openhtml version: Resolves vulnerability in pdfbox
* Added commons-io: Was a transitive dependency lost in spring-boot-starter-parent upgrade
* Removed unused dependencies from /service
* Added maven dependency plugin to /integration
* Removed unused dependencies from /integration

![Screenshot_2021-06-17_at_14.24.26](/uploads/a922e4dd8376347e7e78b2b1e0eaf633/Screenshot_2021-06-17_at_14.24.26.png)

- spring-security vulnerabilities are false positives and not covered in this story