### PR TITLE
IMTA-9344: IMTA-9344: pdfbox-vulnerability

### DIFF
--- a/integration/README.md
+++ b/integration/README.md
@@ -7,6 +7,7 @@ This project is a standalone maven project for running automated integration tes
 ## How To Run
 
 Before running the tests start up the service as per the root README
+Also run `frontend-notification-microservice` - this is needed to serve stylesheets used to generate the certificate
 
 ## How To Test
 
@@ -19,6 +20,7 @@ mvn clean verify \
   -Dtest.openid.service.auth.username=poc \
   -Dtest.openid.service.auth.password=XXXX
   -Dservice.base.url=http://localhost:6060
+  -Dfrontend.notification.base.url=http://localhost:8000
 ```
 
 You can also run: ```cd ../ && ./runIntegration.sh```which is picking up needed values from .env
@@ -34,5 +36,6 @@ SERVICE_USERNAME=username
 SERVICE_PASSWORD=password1
 ```
 
-and this parameter:
+and these parameters:
 `-Dservice.base.url=http://localhost:6060`
+`-Dfrontend.notification.base.url=http://localhost:8000`

--- a/integration/pom.xml
+++ b/integration/pom.xml
@@ -12,6 +12,10 @@
     <version>2.0.19</version>
   </parent>
 
+  <properties>
+    <commons-io.version>2.10.0</commons-io.version>
+  </properties>
+
   <dependencyManagement>
     <dependencies>
       <dependency>
@@ -70,6 +74,11 @@
       <groupId>org.springframework</groupId>
       <artifactId>spring-test</artifactId>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <version>${commons-io.version}</version>
     </dependency>
   </dependencies>
     <name>TracesX-Certificate-Integration</name>

--- a/integration/src/main/java/uk/gov/defra/tracesx/integration/certificate/Properties.java
+++ b/integration/src/main/java/uk/gov/defra/tracesx/integration/certificate/Properties.java
@@ -5,4 +5,8 @@ public class Properties {
   public static final String SERVICE_BASE_URL = System
       .getProperty("service.base.url", "http://localhost:6060");
 
+  public static final String FRONTEND_NOTIFICATION_URL = System
+          .getProperty("frontend.notification.base.url", "http://localhost:8000");
+
+
 }

--- a/integration/src/test/java/uk/gov/defra/tracesx/certificate/integration/CertificateServiceTest.java
+++ b/integration/src/test/java/uk/gov/defra/tracesx/certificate/integration/CertificateServiceTest.java
@@ -1,14 +1,20 @@
 package uk.gov.defra.tracesx.certificate.integration;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.defra.tracesx.integration.certificate.Properties.FRONTEND_NOTIFICATION_URL;
 
 import io.restassured.response.Response;
+import org.apache.commons.io.IOUtils;
 import org.apache.http.HttpStatus;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
+
+import java.io.InputStream;
+import java.nio.charset.Charset;
+import java.io.IOException;
 
 @RunWith(SpringRunner.class)
 @ContextConfiguration(classes = CertificateTestConfig.class)
@@ -50,11 +56,11 @@ public class CertificateServiceTest {
   }
 
   @Test
-  public void shouldCreateCertificateWithFont() {
-    String htmlContent = "<p style='font-family: Arial Unicode MS;'>hello world</p>";
-    String callBackUrl = "";
+  public void shouldCreateCertificateWithFontAndStyles() throws IOException {
+    InputStream inputStream = getClass().getClassLoader().getResourceAsStream("certificate.html");
+    String htmlContent = IOUtils.toString(inputStream, Charset.defaultCharset());
+    String callBackUrl = FRONTEND_NOTIFICATION_URL;
     Response response = certificateApi.getPdf(htmlContent, REFERENCE, callBackUrl);
-
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.SC_OK);
   }
 }

--- a/integration/src/test/resources/certificate.html
+++ b/integration/src/test/resources/certificate.html
@@ -1,0 +1,420 @@
+<html lang="en"><head><title>Certificate - Import and export applications - GOV.UK</title><link rel="shortcut icon" href="/public/images/favicon.ico?0.23.0" /><link href="/public/stylesheets/certificate.css?v&#61;1.0.0" rel="stylesheet" /></head><body class="">
+<main class="certificate">
+    <div class="certificate-header">
+        <table class="table table-full-width"><thead class="govuk-table__head"><tr><th class="text-left text-uppercase"> Great Britain, Channel Islands and Isle of Man</th></tr></thead></table>
+    </div>  <div class="certificate-watermark">
+    <div class="wrapper">
+        <img src="/public/images/statuses/draft.png" alt="Certificate watermark" />
+    </div>
+</div>  <div class="certificate-section">
+    <table class="table table-full-width table-vertical-align-bottom"><tbody><tr><td class="text-left width-70-percent bold padding-bottom-3">
+        <h5 class="certificate-section-title">
+
+
+            Common Health Entry Document <br /> for Feed and Food of Non-Animal Origin
+        </h5>
+    </td><td class="text-right bold padding-bottom-3">
+        <h5 class="certificate-section-title text-uppercase">
+            PART I: Description of consignment
+
+
+        </h5>
+    </td></tr></tbody></table>    <table class="table table-full-width table-bordered table-vertical-align-top"><tbody><tr><td class="width-25-percent">
+    <h5 class="section-heading">I.2. CHED Reference</h5>
+    <p class="section-value">CHEDA.GB.2018.1234567</p>
+</td><td class="width-25-percent no-padding">
+    <table class="table table-full-width table-minimal"><tbody><tr><td>
+        <h5 class="section-heading">I.3. Local Reference</h5>
+        <p class="section-value"></p>
+    </td></tr><tr><td>
+        <h5 class="section-heading">I.4. Border Control Post/Control Point/Control Unit</h5>
+        <p class="section-value"></p>
+    </td></tr><tr><td>
+        <h5 class="section-heading">I.5. Border Control Post/Control Point/Control Unit code</h5>
+        <p class="section-value"></p>
+    </td></tr></tbody></table>
+</td><td class="width-50-percent">
+    <h5 class="section-heading">I.1. Consignor/Exporter</h5>
+
+    <table class="table table-full-width table-review"><tbody><tr><td class="width-25-percent">Name</td><td colspan="3" class="bold"></td></tr><tr><td>Address</td><td colspan="3" class="bold"></td></tr><tr><td>Country</td><td class="bold width-30-percent"></td><td class="width-25-percent">ISO Code</td><td class="bold"></td></tr></tbody></table>        </td></tr><tr><td colspan="2">
+    <h5 class="section-heading">I.6. Consignee/Importer</h5>
+
+    <table class="table table-full-width table-review"><tbody><tr><td class="width-25-percent">Name</td><td colspan="3" class="bold"></td></tr><tr><td>Address</td><td class="bold" colspan="3"></td></tr><tr><td>Country</td><td class="bold width-30-percent"></td><td class="width-25-percent">ISO Code</td><td class="bold"></td></tr></tbody></table>        </td><td>
+    <h5 class="section-heading">I.7.
+        Place of destination</h5>
+
+    <table class="table table-full-width table-review"><tbody><tr><td class="width-25-percent">Name</td><td colspan="3" class="bold"></td></tr><tr><td>Address</td><td class="bold" colspan="3"></td></tr><tr><td>Country</td><td class="bold width-30-percent"></td><td class="width-25-percent">ISO Code</td><td class="bold"></td></tr></tbody></table>        </td></tr><tr><td colspan="2">
+    <h5 class="section-heading">I.8. Operator responsible for the consignment</h5>
+
+    <table class="table table-full-width table-review"><tbody><tr><td class="width-25-percent">Name</td><td colspan="3" class="bold">B2C Inspector</td></tr><tr><td class="width-25-percent">Organisation</td><td colspan="3" class="bold">Belfast Port</td></tr><tr><td>Address</td><td colspan="3" class="bold"></td></tr><tr><td>Country</td><td class="bold width-30-percent">United Kingdom</td><td class="width-25-percent">ISO Code</td><td class="bold">GB</td></tr></tbody></table>        </td><td>
+    <h5 class="section-heading">I.9. Accompanying documents</h5>
+
+    <table class="table table-full-width table-review"><tbody><tr><td class="width-40-percent">Type</td><td colspan="3" class="bold"></td></tr><tr><td>Document reference</td><td colspan="3" class="bold"></td></tr><tr><td>Date of issue</td><td colspan="3" class="bold"></td></tr><tr><td>Country and place of issue</td><td colspan="3" class="bold"> ()</td></tr><tr><td>Name of Signatory</td><td colspan="3" class="bold"></td></tr><tr><td>Commercial documentary references</td><td colspan="3" class="bold"></td></tr></tbody></table>        </td></tr><tr><td colspan="3">
+    <h5 class="section-heading">I.10. Prior notification</h5>
+
+    <table class="table table-full-width table-review"><tbody><tr><td class="width-15-percent">Date</td><td class="width-35-percent bold">
+    </td><td class="width-15-percent">Time</td><td class="width-35-percent bold">
+    </td></tr></tbody></table>        </td></tr><tr><td colspan="2">
+    <h5 class="section-heading">I.13. Means of transport</h5>
+
+    <table class="table table-full-width table-details"><thead class="govuk-table__head"><tr><th class="govuk-table__header">Mode</th><th class="govuk-table__header">International transport document</th><th class="govuk-table__header">Identification</th></tr></thead><tbody><tr><td class="bold text-uppercase"></td><td class="bold text-uppercase"></td><td class="bold text-uppercase"></td></tr></tbody></table>        </td><td class="no-padding">
+    <table class="table table-full-width table-minimal"><tbody><tr><td>
+        <h5 class="section-heading">I.11. Country of Origin</h5>
+        <p class="section-value">Afghanistan</p>
+    </td><td>
+        <h5 class="section-heading">ISO Code</h5>
+        <p class="section-value bordered">
+            AF
+        </p>
+    </td></tr><tr><td>
+        <h5 class="section-heading">I.12. Region of Origin</h5>
+        <p class="section-value"></p>
+    </td><td>
+    </td></tr></tbody></table>
+</td></tr><tr><td colspan="3">
+    <table class="table table-full-width table-review"><tbody><tr><td class="width-85-percent">
+        <h5 class="section-heading">I.14. Country of dispatch</h5>
+    </td><td class="width-15-percent text-center">ISO Code</td></tr><tr><td class="width-85-percent bold">
+        Afghanistan
+    </td><td class="width-15-percent bold text-center border-left-only">
+        AF
+    </td></tr></tbody></table>        </td></tr><tr><td colspan="3">
+    <h5 class="section-heading">I.15. Establishment of Origin</h5>
+    <table class="table table-full-width table-review"><tbody><tr><td class="width-15-percent">Name</td><td colspan="3" class="bold"></td></tr><tr><td>Address</td><td colspan="3"></td></tr><tr><td>Approval Number</td><td class="bold"></td></tr><tr><td>Country</td><td class="bold width-50-percent"></td><td class="width-25-percent">ISO Code</td><td class="bold"></td></tr></tbody></table>
+
+</td></tr><tr><td colspan="3">
+    <table class="table-full-width table-borderless"><tbody><tr><td class="width-40-percent">
+        <h5 class="section-heading">I.16. Transport conditions</h5>
+    </td></tr><tr><td class="width-30-percent">
+        <div class="checkbox-with-label">
+            <span class="label bold">Ambient</span>
+            <span class="checkbox "></span>
+        </div>
+    </td><td class="width-30-percent">
+        <div class="checkbox-with-label">
+            <span class="label bold">Chilled</span>
+            <span class="checkbox "></span>
+        </div>
+    </td><td class="width-30-percent">
+        <div class="checkbox-with-label">
+            <span class="label bold">Frozen</span>
+            <span class="checkbox "></span>
+        </div>
+    </td></tr></tbody></table>        </td></tr><tr><td colspan="3">
+    <h5 class="section-heading">I.17. Container No/Seal No</h5>
+
+</td></tr><tr><td colspan="3">
+    <table class="table-full-width table-borderless"><tbody><tr><td class="width-40-percent">
+        <h5 class="section-heading">I.18. Goods certified as</h5>
+    </td></tr><tr><td class="width-30-percent bold">
+
+    </td></tr></tbody></table>        </td></tr><tr><td colspan="2">
+    <h5 class="section-heading">I.27. Means of transport after BCP/storage</h5>
+
+    <table class="table table-full-width table-details"><thead class="govuk-table__head"><tr><th class="govuk-table__header">Mode</th><th class="govuk-table__header">International transport document</th><th class="govuk-table__header">Identification</th></tr></thead><tbody><tr><td class="bold text-uppercase"></td><td class="bold text-uppercase"></td><td class="bold text-uppercase"></td></tr></tbody></table>        </td><td>
+    <h5 class="section-heading">I.28. Transporter</h5>
+
+    <table class="table table-full-width table-review"><tbody><tr><td class="width-25-percent">Name</td><td colspan="3" class="bold"></td></tr><tr><td>Address</td><td colspan="3" class="bold"></td></tr><tr><td>Country</td><td class="bold width-30-percent"></td><td class="width-25-percent">ISO Code</td><td class="bold"></td></tr><tr><td>Approval number</td><td colspan="3" class="bold"></td></tr></tbody></table>
+</td></tr><tr><td colspan="3">
+    <table class="table-full-width table-borderless"><tbody><tr><td class="width-40-percent">
+        <h5 class="section-heading">I.29. Date of departure</h5>
+    </td><td class="bold">
+
+    </td></tr></tbody></table>        </td></tr><tr><td colspan="3">
+    <h5 class="section-heading">I.31. Description of the goods</h5>
+    <table class="table table-full-width table-review"><tbody><tr><td>
+        <ol class="commodities"></ol>
+    </td></tr></tbody></table>
+
+
+
+    <table class="table table-full-width table-details margin-top-10"><thead class="govuk-table__head"><tr><th class="govuk-table__header">Commodity</th><th class="govuk-table__header">Country of Origin</th><th class="govuk-table__header">Net weight</th><th class="govuk-table__header">Package count</th></tr></thead><tbody></tbody></table>
+</td></tr><tr><td colspan="3" class="no-padding">
+    <div class="columns clearfix">
+        <div class="column column-quarter fixed-column-quarter">
+            <h5 class="section-heading">I.32. Total number of packages</h5>
+            <p class="section-value">
+            </p>            </div>
+        <div class="column column-quarter">
+            <h5 class="section-heading">I.34. Total Net Weight</h5>
+            <p class="section-value">
+            </p>            </div>
+        <div class="column column-quarter">
+            <h5 class="section-heading">I.34. Total Gross Weight</h5>
+            <p class="section-value">
+                Kg
+            </p>
+        </div>
+    </div>
+</td></tr><tr><td colspan="3">
+    <h5 class="section-heading">I.35. Declaration</h5>
+
+    <p class="margin-top-5">
+        I, the undersigned operator responsible for the consignment detailed above, certify that to the
+        best of my knowledge and belief the statements made in Part I of this document are true and complete,
+        and I agree to comply with the requirements of Regulation 2017/625 on official controls,
+        including payment for official controls, as well as for re-dispatching consignments, quarantine or
+        isolation of consignments, or costs of destruction and disposal where necessary.
+    </p>
+
+    <table class="table table-full-width table-review"><tbody><tr><td class="width-30-percent">
+        <h5 class="section-heading">Date of signature</h5>
+        <p class="section-value bold"></p>
+    </td><td class="width-30-percent">
+        <h5 class="section-heading">Name of signatory</h5>
+        <p class="section-value bold">B2C Inspector</p>
+    </td><td class="width-30-percent">
+        <h5 class="section-heading">Signature</h5>
+    </td></tr></tbody></table>        </td></tr></tbody></table>
+</div>
+
+    <div class="certificate-section certificate-section-two">
+        <table class="table table-full-width table-vertical-align-bottom"><tbody><tr><td class="text-left width-70-percent bold padding-bottom-3">
+            <h5 class="certificate-section-title">
+
+
+                Common Health Entry Document <br /> for Feed and Food of Non-Animal Origin
+            </h5>
+        </td><td class="text-right bold padding-bottom-3">
+            <h5 class="certificate-section-title text-uppercase">
+
+                PART II: Controls
+
+            </h5>
+        </td></tr></tbody></table>    <table class="table table-full-width table-bordered table-vertical-align-top"><tbody><tr><td colspan="3" class="no-padding">
+        <div class="columns clearfix">
+            <div class="column column-third">
+                <h5 class="section-heading">II.1. Previous CHED</h5>
+                <p class="section-value">
+                </p>
+            </div>
+            <div class="column column-third">
+                <h5 class="section-heading">II.2. CHED Reference</h5>
+                <p class="section-value">CHEDA.GB.2018.1234567</p>
+            </div>
+            <div class="column column-third">
+                <h5 class="section-heading">II.24. Subsequent CHEDs</h5>
+                <p class="section-value">
+                </p>
+            </div>
+        </div>
+    </td></tr><tr><td class="width-50-percent">
+        <h5 class="section-heading">II.3. Documentary Check</h5>
+
+        <table class="table table-full-width table-borderless margin-top-5"><tbody><tr><td class="width-30-percent">EU Standard</td><td class="width-25-percent">
+            <div class="checkbox-with-label">
+                <span class="label">Satisfactory</span>
+                <span class="checkbox "></span>
+            </div>
+        </td><td class="width-25-percent">
+            <div class="checkbox-with-label">
+                <span class="label">Not Satisfactory</span>
+                <span class="checkbox "></span>
+            </div>
+        </td></tr></tbody></table>        </td><td class="width-50-percent">
+        <table class="table table-full-width table-borderless"><tbody><tr><td class="width-60-percent padding-top-0">II.4. Identity Check</td><td class="width-20-percent padding-top-0">
+            <div class="checkbox-with-label">
+                <span class="label">Yes</span>
+                <span class="checkbox "></span>
+            </div>
+        </td><td class="width-20-percent padding-top-0">
+            <div class="checkbox-with-label">
+                <span class="label">No</span>
+                <span class="checkbox "></span>
+            </div>
+        </td></tr></tbody></table>
+        <table class="table table-full-width table-borderless margin-top-5"><tbody><tr><td class="width-5-percent padding-top-0"></td><td class="width-15-percent padding-top-0">
+            <div class="checkbox-with-label">
+                <span class="label">Satisfactory</span>
+                <span class="checkbox "></span>
+            </div>
+        </td><td class="width-20-percent padding-top-0">
+            <div class="checkbox-with-label">
+                <span class="label">Not Satisfactory</span>
+                <span class="checkbox "></span>
+            </div>
+        </td></tr></tbody></table>        </td></tr><tr><td class="width-50-percent">
+        <table class="table table-full-width table-borderless"><tbody><tr><td class="width-60-percent padding-top-0">II.5. Physical Check</td><td class="width-20-percent padding-top-0">
+            <div class="checkbox-with-label">
+                <span class="label">Yes</span>
+                <span class="checkbox "></span>
+            </div>
+        </td><td class="width-20-percent padding-top-0">
+            <div class="checkbox-with-label">
+                <span class="label">No</span>
+                <span class="checkbox "></span>
+            </div>
+        </td></tr></tbody></table>
+
+
+        <table class="table table-full-width table-borderless margin-top-5"><tbody><tr><td class="width-5-percent padding-top-0"></td><td class="width-15-percent padding-top-0">
+            <div class="checkbox-with-label">
+                <span class="label">Satisfactory</span>
+                <span class="checkbox "></span>
+            </div>
+        </td><td class="width-20-percent padding-top-0">
+            <div class="checkbox-with-label">
+                <span class="label">Not Satisfactory</span>
+                <span class="checkbox "></span>
+            </div>
+        </td></tr></tbody></table>        </td><td class="width-50-percent">
+        <table class="table table-full-width table-borderless"><tbody><tr><td class="width-60-percent padding-top-0">II.6. Laboratory tests</td><td class="width-20-percent padding-top-0">
+            <div class="checkbox-with-label">
+                <span class="label">Yes</span>
+                <span class="checkbox "></span>
+            </div>
+        </td><td class="width-20-percent padding-top-0">
+            <div class="checkbox-with-label">
+                <span class="label">No</span>
+                <span class="checkbox "></span>
+            </div>
+        </td></tr></tbody></table>
+        <table class="table table-full-width table-borderless margin-top-5"><tbody><tr><td class="width-15-percent">Test</td><td colspan="3" class="width-15-percent padding-bottom-3 bold"></td></tr><tr><td class="width-15-percent"></td><td class="width-20-percent">
+            <div class="checkbox-with-label">
+                <span class="label">Random</span>
+                <span class="checkbox"></span>
+            </div>
+        </td><td class="width-20-percent">
+            <div class="checkbox-with-label">
+                <span class="label">Suspicion</span>
+                <span class="checkbox"></span>
+            </div>
+        </td><td class="width-25-percent">
+        </td></tr><tr><td class="width-15-percent">Results</td><td class="width-20-percent">
+            <div class="checkbox-with-label">
+                <span class="label">Pending</span>
+                <span class="checkbox"></span>
+            </div>
+        </td><td class="width-20-percent">
+            <div class="checkbox-with-label">
+                <span class="label">Satisfactory</span>
+                <span class="checkbox"></span>
+            </div>
+        </td><td class="width-25-percent">
+            <div class="checkbox-with-label">
+                <span class="label">Not Satisfactory</span>
+                <span class="checkbox"></span>
+            </div>
+        </td></tr></tbody></table>
+    </td></tr><tr><td class="no-padding">
+        <table class="table table-full-width table-minimal"><tbody><tr><td>
+            <h5 class="section-heading">II.20. Identification of BCP</h5>
+
+            <table class="table table-full-width table-review"><tbody><tr><td class="width-20-percent">BCP</td><td class="bold width-30-percent"></td><td>Stamp</td></tr><tr><td>Unit number</td><td colspan="2" class="bold"></td></tr></tbody></table>
+        </td></tr><tr><td>
+            <h5 class="section-heading">II.22. Inspection fees</h5>              </td></tr></tbody></table>
+    </td><td>
+        <h5 class="section-heading">II.21. Certifying officer</h5>
+        <p class="margin-top-5">
+            I, the undersigned official inspector for the entry point, certify that the checks on the consignment have been carried out in accordance with EU retained law.
+
+        </p>
+
+        <table class="table table-full-width table-review"><tbody><tr><td class="width-20-percent">Full name</td><td class="bold width-30-percent"></td><td>Signature</td></tr><tr><td>Date of signature</td><td colspan="2" class="bold"></td></tr></tbody></table>        </td></tr><tr><td colspan="3">
+        <table class="table-full-width table-borderless"><tbody><tr><td class="width-40-percent">
+            <h5 class="section-heading">II.23. Customs Document Reference</h5>
+        </td><td class="width-50-percent bold">
+        </td></tr></tbody></table>        </td></tr></tbody></table>
+    </div>
+    <div class="certificate-section certificate-section-three">
+        <table class="table table-full-width table-vertical-align-bottom"><tbody><tr><td class="text-left width-70-percent bold padding-bottom-3">
+            <h5 class="certificate-section-title">
+
+
+                Common Health Entry Document <br /> for Feed and Food of Non-Animal Origin
+            </h5>
+        </td><td class="text-right bold padding-bottom-3">
+            <h5 class="certificate-section-title text-uppercase">
+
+
+                PART III: Follow up
+            </h5>
+        </td></tr></tbody></table>  <table class="table table-full-width table-bordered table-vertical-align-top"><tbody><tr><td colspan="3" class="no-padding">
+        <div class="columns clearfix">
+            <div class="column column-third">
+                <h5 class="section-heading">III.1. Previous CHED</h5>
+                <p class="section-value">
+                </p>
+            </div>
+            <div class="column column-third">
+                <h5 class="section-heading">III.2. CHED Reference</h5>
+                <p class="section-value">CHEDA.GB.2018.1234567</p>
+            </div>
+            <div class="column column-third">
+                <h5 class="section-heading">III.24. Subsequent CHED</h5>
+                <p class="section-value">
+                </p>
+            </div>
+        </div>
+    </td></tr><tr><td colspan="3">
+        <table class="table table-full-width table-review no-border"><tbody><tr><td class="width-40-percent">
+            <h5 class="section-heading">III.4 Details on re-dispatching</h5>
+        </td></tr><tr><td class="width-40-percent">
+            Country of destination
+        </td><td class="width-40-percent bold">
+
+        </td><td class="width-10-percent">
+            ISO Code
+        </td><td class="width-10-percent bold">
+
+        </td></tr><tr><td class="width-25-percent">
+            Exit authority
+        </td><td class="width-25-percent bold">
+
+        </td><td class="width-25-percent">
+            Code
+        </td><td class="width-25-percent bold">
+
+        </td></tr><tr><td>Means of transport</td></tr><tr><td class="no-padding" colspan="4">
+            <table class="table table-full-width table-details"><thead class="govuk-table__head"><tr><th class="govuk-table__header">Mode</th><th class="govuk-table__header">International transport document</th><th class="govuk-table__header">Identification</th></tr></thead><tbody><tr><td class="bold"></td><td class="bold"></td><td class="bold"></td></tr></tbody></table>
+        </td></tr><tr><td class="width-25-percent">Date and time</td><td class="width-50-percent bold"></td></tr></tbody></table>      </td></tr><tr><td colspan="3">
+        <table class="table-full-width table-review"><tbody><tr><td class="width-40-percent">
+            <h5 class="section-heading">III.5 Follow up</h5>
+        </td></tr><tr><td class="width-50-percent">
+            <div class="checkbox-with-label">
+                <span class="label">Local competent authority</span>
+                <span class="checkbox"></span>
+            </div>
+        </td><td class="width-50-percent">
+            <div class="checkbox-with-label">
+                <span class="label">Second entry point</span>
+                <span class="checkbox"></span>
+            </div>
+        </td></tr><tr><td>
+            <table class="table-review"><tbody><tr><td class="width-10-percent">
+                Arrival of consignment
+            </td><td class="width-5-percent">
+                <div class="checkbox-with-label">
+                    <span class="label">Yes</span>
+                    <span class="checkbox "></span>
+                </div>
+            </td><td class="width-5-percent">
+                <div class="checkbox-with-label">
+                    <span class="label">No</span>
+                    <span class="checkbox "></span>
+                </div>
+            </td></tr><tr><td class="width-10-percent">
+                Compliance of the consignment
+            </td><td class="width-5-percent">
+                <div class="checkbox-with-label">
+                    <span class="label">Yes</span>
+                    <span class="checkbox"></span>
+                </div>
+            </td><td class="width-5-percent">
+                <div class="checkbox-with-label">
+                    <span class="label">No</span>
+                    <span class="checkbox
+                          "></span>
+                </div>
+            </td></tr></tbody></table>
+        </td></tr></tbody></table>      </td></tr><tr><td colspan="3">
+        <table class="table-full-width table-review"><tbody><tr><td class="width-10-percent">
+            <h5 class="section-heading">III.6 Official Inspector</h5>
+        </td></tr><tr><td></td></tr><tr><td class="width-10-percent">Full name</td><td class="width-10-percent bold">
+
+
+        </td><td class="width-10-percent">Date of signature</td><td class="width-10-percent bold"></td></tr><tr><td class="padding-top-15 padding-bottom-50">Signature</td></tr></tbody></table>      </td></tr></tbody></table>
+    </div>  <div>
+</div></main>
+
+</body></html>

--- a/runIntegration.sh
+++ b/runIntegration.sh
@@ -7,3 +7,4 @@ mvn test -f integration/pom.xml \
     -Dtest.openid.service.auth.username=$TEST_OPENID_TOKEN_SERVICE_AUTH_USERNAME \
     -Dtest.openid.service.auth.password=$TEST_OPENID_TOKEN_SERVICE_AUTH_PASSWORD \
     -Dservice.base.url=http://localhost:6060
+    -Dfrontend.notification.base.url=http://localhost:8000

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -17,7 +17,7 @@
   </parent>
 
   <properties>
-    <openhtml.version>1.0.1</openhtml.version>
+    <openhtml.version>1.0.9</openhtml.version>
     <owasp-java-html-sanitizer.version>20181114.1</owasp-java-html-sanitizer.version>
     <commons-io.version>2.10.0</commons-io.version>
   </properties>


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | Kelly Moore |
> | **GitLab Project** | [imports/certificate-microservice](https://giteux.azure.defra.cloud/imports/certificate-microservice) |
> | **GitLab Merge Request** | [IMTA-9344: IMTA-9344: pdfbox-vulnerabili...](https://giteux.azure.defra.cloud/imports/certificate-microservice/merge_requests/74) |
> | **GitLab MR Number** | [74](https://giteux.azure.defra.cloud/imports/certificate-microservice/merge_requests/74) |
> | **Date Originally Opened** | Mon, 5 Jul 2021 |
> | **Approved on GitLab by** | Stephen Donaghey (KAINOS), Stephen McVeigh, kingsley.Osime (Kainos) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

### :link: Ticket: https://eaflood.atlassian.net/browse/IMTA-9344

### :book: Changes:
* Upgrade `openhtml` to `1.0.9` to resolve vulnerability
* Extend integration tests to create PDF from HTML generate in IPAFFS with links to stylesheet (Before we were only using sample HTML and integration tests would pass as our font and styles weren't being referenced and therefore not tested)
  *  Added `frontend.notification.base.url` to use in integration tests. The callback url passed is used to build a url to fetch the stylesheets from. We need to be able to set this to local or integration frontend.
  * https://giteux.azure.defra.cloud/imports/pipeline-library/merge_requests/1107
  * https://defra.sharepoint.com/:t:/r/sites/def-ddts-euexitpmo/Shared%20Documents/Sub%20-%20Projects/APH001%20Import%20Notifications/36%20Technical%20Artefacts/Running%20integration%20tests/certificate.txt?csf=1&web=1&e=rsfsTi